### PR TITLE
fix: run on amd64 only 

### DIFF
--- a/src/httpcache.ts
+++ b/src/httpcache.ts
@@ -72,6 +72,10 @@ export class PloneHttpcache extends Construct {
           { name: 'FRONTEND_SERVICE_NAME', value: options.plone.frontendServiceName },
           { name: 'FRONTEND_SERVICE_PORT', value: '3000' },
         ],
+        // see https://github.com/mittwald/kube-httpcache/issues/253
+        nodeSelector: {
+          'kubernetes.io/arch': 'amd64',
+        },
         resources: {
           limits: {
             cpu: options.limitCpu || '500m',

--- a/test/__snapshots__/httpcache.test.ts.snap
+++ b/test/__snapshots__/httpcache.test.ts.snap
@@ -481,6 +481,9 @@ exports[`defaults 1`] = `
               ],
             },
           ],
+          "nodeSelector": {
+            "kubernetes.io/arch": "amd64",
+          },
           "securityContext": {},
           "serviceAccountName": "plone-test-httpcache-c8667035-kube-httpcache",
           "volumes": [


### PR DESCRIPTION
workaround for https://github.com/mittwald/kube-httpcache/issues/253

