### PR TITLE
chore: Fix version display in documentation

### DIFF
--- a/documentation/sources/conf.py
+++ b/documentation/sources/conf.py
@@ -22,7 +22,21 @@ copyright = "2024-2025, Blue Dynamics Alliance"
 author = "Blue Dynamics Alliance Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.0"
+# Read version from git tags
+import subprocess
+
+try:
+    # Get the latest git tag
+    result = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    release = result.stdout.strip().lstrip("v")  # Remove 'v' prefix if present
+except (subprocess.CalledProcessError, FileNotFoundError):
+    # Fallback to 0.0.0 if git is not available or no tags exist
+    release = "0.0.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes hardcoded version "0.0.0" in Sphinx documentation
- Documentation now displays the correct version from git tags (currently 0.1.8)
- Uses `git describe --tags --abbrev=0` to dynamically fetch version at build time
- Includes fallback to "0.0.0" if git is unavailable

## Changes

Modified `documentation/sources/conf.py` to read version dynamically from git tags instead of using a hardcoded value.

## Test plan

- [x] Built documentation locally and verified version shows as 0.1.8
- [x] Verified version appears in page titles and metadata
- [ ] After merge, verify GitHub Pages deployment shows correct version

## Impact

Once merged, the documentation at https://bluedynamics.github.io/cdk8s-plone/ will display the actual release version instead of 0.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)