### PR TITLE
chore: Skip releases for documentation and examples changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - documentation/**
+      - examples/**
+      - "*.md"
+      - .github/workflows/documentation.yml
   workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -69,4 +69,15 @@ project.addTask('import:servicemonitor', {
 //   upgradeMain.addOverride('jobs.pr.steps.4.with.token', '${{ github.token }}');
 // }
 
+// Configure release workflow to skip documentation and examples changes
+const releaseWorkflow = project.tryFindObjectFile('.github/workflows/release.yml');
+if (releaseWorkflow) {
+  releaseWorkflow.addOverride('on.push.paths-ignore', [
+    'documentation/**',
+    'examples/**',
+    '*.md',
+    '.github/workflows/documentation.yml',
+  ]);
+}
+
 project.synth();


### PR DESCRIPTION
## Summary

Configure the release workflow to skip package releases when only documentation or examples are modified.

## Changes

Modified `.projenrc.ts` to add `paths-ignore` to the release workflow for:
- `documentation/**` - Documentation files
- `examples/**` - Example code
- `*.md` - Markdown files (README, etc.)
- `.github/workflows/documentation.yml` - Documentation workflow

## Why

Documentation and example updates don't require new package versions to be published to npm/PyPI. This change prevents unnecessary releases and version bumps for non-code changes.

## Test plan

- [x] Verified workflow regenerates correctly with `npx projen`
- [ ] After merge, verify that documentation/example-only commits don't trigger releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)