### PR TITLE
chore(release): add environment for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    environment: release
   release_pypi:
     name: Publish to PyPI
     needs: release

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -78,6 +78,8 @@ if (releaseWorkflow) {
     '*.md',
     '.github/workflows/documentation.yml',
   ]);
+  // Use OIDC trusted publishing for npm instead of NPM_TOKEN
+  releaseWorkflow.patch(JsonPatch.add('/jobs/release_npm/environment', 'release'));
 }
 
 project.synth();


### PR DESCRIPTION
## Summary

- Adds `environment: release` to the `release_npm` job in the release workflow
- This enables npm OIDC trusted publishing, replacing the need for the `NPM_TOKEN` secret
- The npm trusted publisher is configured to require the `release` environment

## Context

The npm trusted publisher was configured on npmjs.com with environment name `release`, but the workflow job was missing the `environment` declaration. Without it, npm rejects the OIDC token from GitHub Actions.

## Test plan

- [ ] Merge and verify the next release publishes to npm successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)