### PR TITLE
fix(release): use NPM_TRUSTED_PUBLISHER for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
     environment: release
   release_pypi:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -80,6 +80,8 @@ if (releaseWorkflow) {
   ]);
   // Use OIDC trusted publishing for npm instead of NPM_TOKEN
   releaseWorkflow.patch(JsonPatch.add('/jobs/release_npm/environment', 'release'));
+  releaseWorkflow.patch(JsonPatch.remove('/jobs/release_npm/steps/9/env/NPM_TOKEN'));
+  releaseWorkflow.patch(JsonPatch.add('/jobs/release_npm/steps/9/env/NPM_TRUSTED_PUBLISHER', 'true'));
 }
 
 project.synth();


### PR DESCRIPTION
## Summary

- Replaces `NPM_TOKEN` with `NPM_TRUSTED_PUBLISHER=true` in the release_npm job
- `publib-npm` requires this env var to use OIDC token exchange instead of a static token

## Context

Follow-up to #122. The `environment: release` was added but `publib-npm` also needs `NPM_TRUSTED_PUBLISHER=true` to trigger OIDC mode. Without it, it fails with:
```
NPM_TOKEN=<token> or NPM_TRUSTED_PUBLISHER=true is required
```

## Test plan

- [ ] Merge and verify the next release publishes to npm successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)