### PR TITLE
fix(release): use projen npmTrustedPublishing with Node 24 for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: 24.x
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,6 +36,7 @@ const project = new cdk.JsiiProject({
   //   moduleName: 'github.com/bluedynamics/cdk8s-plone-go',
   // },
   npmProvenance: true,
+  npmTrustedPublishing: true,
   npmAccess: NpmAccess.PUBLIC,
   depsUpgradeOptions: {
     workflowOptions: {
@@ -78,10 +79,9 @@ if (releaseWorkflow) {
     '*.md',
     '.github/workflows/documentation.yml',
   ]);
-  // Use OIDC trusted publishing for npm instead of NPM_TOKEN
+  // npm OIDC trusted publishing needs Node 24+ and the 'release' environment
   releaseWorkflow.patch(JsonPatch.add('/jobs/release_npm/environment', 'release'));
-  releaseWorkflow.patch(JsonPatch.remove('/jobs/release_npm/steps/9/env/NPM_TOKEN'));
-  releaseWorkflow.patch(JsonPatch.add('/jobs/release_npm/steps/9/env/NPM_TRUSTED_PUBLISHER', 'true'));
+  releaseWorkflow.patch(JsonPatch.replace('/jobs/release_npm/steps/0/with/node-version', '24.x'));
 }
 
 project.synth();


### PR DESCRIPTION
## Summary

- Use projen's built-in `npmTrustedPublishing: true` for proper OIDC support
- Set Node.js 24.x for the npm publish job (OIDC requires npm CLI 11.5.1+)
- Keep `environment: release` to match npm trusted publisher configuration

## Root cause

npm OIDC trusted publishing requires npm CLI 11.5.1+ (Node 24+). The workflow was using `lts/*` (Node 22) which doesn't have the OIDC token exchange capability, causing `ENEEDAUTH`.

Also, npm classic tokens were permanently revoked on Dec 9, 2025, so `NPM_TOKEN` no longer works.

## Changes

- `.projenrc.ts`: Added `npmTrustedPublishing: true`, replaced manual env patches with Node version + environment patches
- `.github/workflows/release.yml`: Regenerated by projen

## Test plan

- [ ] Merge and verify npm publish succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)