### PR TITLE
fix(release): add registry-url for npm OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24.x
+          registry-url: https://registry.npmjs.org
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -79,9 +79,11 @@ if (releaseWorkflow) {
     '*.md',
     '.github/workflows/documentation.yml',
   ]);
-  // npm OIDC trusted publishing needs Node 24+ and the 'release' environment
+  // npm OIDC trusted publishing needs Node 24+, the 'release' environment,
+  // and registry-url so setup-node creates .npmrc for OIDC auth
   releaseWorkflow.patch(JsonPatch.add('/jobs/release_npm/environment', 'release'));
   releaseWorkflow.patch(JsonPatch.replace('/jobs/release_npm/steps/0/with/node-version', '24.x'));
+  releaseWorkflow.patch(JsonPatch.add('/jobs/release_npm/steps/0/with/registry-url', 'https://registry.npmjs.org'));
 }
 
 project.synth();


### PR DESCRIPTION
## Summary

Adds `registry-url: https://registry.npmjs.org` to the `actions/setup-node` step in the npm publish job.

## Root cause

npm CLI requires `actions/setup-node` to be configured with `registry-url` to create the `.npmrc` entry that enables OIDC token exchange. Without this `.npmrc` entry, npm doesn't attempt OIDC auth and fails with `ENEEDAUTH`.

## Test plan

- [ ] Verify npm publish succeeds via OIDC after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)