### PR TITLE
fix(vinylcache): use cloud-vinyl-varnish image as default

### DIFF
--- a/API.md
+++ b/API.md
@@ -1665,7 +1665,7 @@ public readonly image: string;
 ```
 
 - *Type:* string
-- *Default:* 'varnish:7.6'
+- *Default:* 'ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6'
 
 Container image for the Varnish pods.
 

--- a/src/vinylcache.ts
+++ b/src/vinylcache.ts
@@ -197,7 +197,7 @@ export interface PloneVinylCacheOptions {
 
   /**
    * Container image for the Varnish pods.
-   * @default 'varnish:7.6'
+   * @default 'ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6'
    */
   readonly image?: string;
 
@@ -404,7 +404,7 @@ export class PloneVinylCache extends Construct {
     const vinylCache = new VinylCache(this, 'vinylcache', {
       spec: {
         replicas,
-        image: options.image ?? 'varnish:7.6',
+        image: options.image ?? 'ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6',
         backends,
         director: { type: directorType },
         vcl: {

--- a/test/__snapshots__/vinylcache.test.ts.snap
+++ b/test/__snapshots__/vinylcache.test.ts.snap
@@ -263,7 +263,7 @@ exports[`defaults 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -493,7 +493,7 @@ exports[`with classic-ui variant (no frontend) 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -850,7 +850,7 @@ exports[`with custom VCL snippets 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -1147,7 +1147,7 @@ exports[`with custom replicas and resources 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -1518,7 +1518,7 @@ exports[`with extraBackends 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -1875,7 +1875,7 @@ exports[`with invalidation disabled 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "replicas": 2,
       "resources": {
         "limits": {
@@ -2221,7 +2221,7 @@ exports[`with monitoring enabled 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -2584,7 +2584,7 @@ exports[`with nodeSelector 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -2947,7 +2947,7 @@ exports[`with nodeSelector and tolerations 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -3317,7 +3317,7 @@ exports[`with shard director 1`] = `
       "director": {
         "type": "round_robin",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,
@@ -3674,7 +3674,7 @@ exports[`with tolerations 1`] = `
       "director": {
         "type": "shard",
       },
-      "image": "varnish:7.6",
+      "image": "ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6",
       "invalidation": {
         "ban": {
           "enabled": true,


### PR DESCRIPTION
## Problem

The default image `varnish:7.6` has a non-numeric user (`varnish`), which fails Kubernetes `runAsNonRoot` validation:

```
Error: container has runAsNonRoot and image has non-numeric user (varnish),
cannot verify user is non-root
```

## Fix

Change default image to `ghcr.io/bluedynamics/cloud-vinyl-varnish:7.6` which uses numeric UID 65532 and is the intended image for the cloud-vinyl operator.