### PR TITLE
feat(plone): add securityContext support to PloneBaseOptions

### DIFF
--- a/API.md
+++ b/API.md
@@ -726,6 +726,7 @@ const ploneBaseOptions: PloneBaseOptions = { ... }
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneBaseOptions.property.replicas">replicas</a></code> | <code>number</code> | Number of pod replicas to run. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneBaseOptions.property.requestCpu">requestCpu</a></code> | <code>string</code> | CPU request for the container. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneBaseOptions.property.requestMemory">requestMemory</a></code> | <code>string</code> | Memory request for the container. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneBaseOptions.property.securityContext">securityContext</a></code> | <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext">PloneSecurityContext</a></code> | Security context for the container. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneBaseOptions.property.serviceAnnotations">serviceAnnotations</a></code> | <code>{[ key: string ]: string}</code> | Annotations to add to the Service metadata. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneBaseOptions.property.servicemonitor">servicemonitor</a></code> | <code>boolean</code> | Enable Prometheus ServiceMonitor for metrics collection. |
 
@@ -1159,6 +1160,28 @@ Memory request for the container.
 ```
 
 
+##### `securityContext`<sup>Optional</sup> <a name="securityContext" id="@bluedynamics/cdk8s-plone.PloneBaseOptions.property.securityContext"></a>
+
+```typescript
+public readonly securityContext: PloneSecurityContext;
+```
+
+- *Type:* <a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext">PloneSecurityContext</a>
+- *Default:* no security context
+
+Security context for the container.
+
+Use to set capabilities, run as non-root, read-only filesystem, etc.
+
+---
+
+*Example*
+
+```typescript
+{ capabilities: { add: ['SYS_PTRACE'] } }
+```
+
+
 ##### `serviceAnnotations`<sup>Optional</sup> <a name="serviceAnnotations" id="@bluedynamics/cdk8s-plone.PloneBaseOptions.property.serviceAnnotations"></a>
 
 ```typescript
@@ -1194,6 +1217,53 @@ Enable Prometheus ServiceMonitor for metrics collection.
 
 Requires Prometheus Operator to be installed in the cluster.
 When enabled, a ServiceMonitor resource will be created to scrape metrics.
+
+---
+
+### PloneCapabilities <a name="PloneCapabilities" id="@bluedynamics/cdk8s-plone.PloneCapabilities"></a>
+
+Linux capabilities to add or drop on a container.
+
+#### Initializer <a name="Initializer" id="@bluedynamics/cdk8s-plone.PloneCapabilities.Initializer"></a>
+
+```typescript
+import { PloneCapabilities } from '@bluedynamics/cdk8s-plone'
+
+const ploneCapabilities: PloneCapabilities = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneCapabilities.property.add">add</a></code> | <code>string[]</code> | Capabilities to add (e.g. 'SYS_PTRACE', 'NET_ADMIN'). |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneCapabilities.property.drop">drop</a></code> | <code>string[]</code> | Capabilities to drop (e.g. 'ALL', 'NET_RAW'). |
+
+---
+
+##### `add`<sup>Optional</sup> <a name="add" id="@bluedynamics/cdk8s-plone.PloneCapabilities.property.add"></a>
+
+```typescript
+public readonly add: string[];
+```
+
+- *Type:* string[]
+- *Default:* no capabilities added
+
+Capabilities to add (e.g. 'SYS_PTRACE', 'NET_ADMIN').
+
+---
+
+##### `drop`<sup>Optional</sup> <a name="drop" id="@bluedynamics/cdk8s-plone.PloneCapabilities.property.drop"></a>
+
+```typescript
+public readonly drop: string[];
+```
+
+- *Type:* string[]
+- *Default:* no capabilities dropped
+
+Capabilities to drop (e.g. 'ALL', 'NET_RAW').
 
 ---
 
@@ -1562,6 +1632,132 @@ public readonly version: string;
 Version string for labeling the deployment.
 
 This is used in Kubernetes labels and doesn't affect the actual image versions.
+
+---
+
+### PloneSecurityContext <a name="PloneSecurityContext" id="@bluedynamics/cdk8s-plone.PloneSecurityContext"></a>
+
+Security context for a Plone container.
+
+Controls privilege and access settings.
+
+#### Initializer <a name="Initializer" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.Initializer"></a>
+
+```typescript
+import { PloneSecurityContext } from '@bluedynamics/cdk8s-plone'
+
+const ploneSecurityContext: PloneSecurityContext = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext.property.allowPrivilegeEscalation">allowPrivilegeEscalation</a></code> | <code>boolean</code> | Allow privilege escalation for the container process. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext.property.capabilities">capabilities</a></code> | <code><a href="#@bluedynamics/cdk8s-plone.PloneCapabilities">PloneCapabilities</a></code> | Linux capabilities to add or drop. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext.property.privileged">privileged</a></code> | <code>boolean</code> | Run the container in privileged mode. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext.property.readOnlyRootFilesystem">readOnlyRootFilesystem</a></code> | <code>boolean</code> | Mount the root filesystem as read-only. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext.property.runAsGroup">runAsGroup</a></code> | <code>number</code> | Run the container as a specific group ID. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext.property.runAsNonRoot">runAsNonRoot</a></code> | <code>boolean</code> | Require the container to run as non-root. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneSecurityContext.property.runAsUser">runAsUser</a></code> | <code>number</code> | Run the container as a specific user ID. |
+
+---
+
+##### `allowPrivilegeEscalation`<sup>Optional</sup> <a name="allowPrivilegeEscalation" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.property.allowPrivilegeEscalation"></a>
+
+```typescript
+public readonly allowPrivilegeEscalation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* undefined
+
+Allow privilege escalation for the container process.
+
+---
+
+##### `capabilities`<sup>Optional</sup> <a name="capabilities" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.property.capabilities"></a>
+
+```typescript
+public readonly capabilities: PloneCapabilities;
+```
+
+- *Type:* <a href="#@bluedynamics/cdk8s-plone.PloneCapabilities">PloneCapabilities</a>
+- *Default:* no capability changes
+
+Linux capabilities to add or drop.
+
+---
+
+*Example*
+
+```typescript
+{ add: ['SYS_PTRACE'] }
+```
+
+
+##### `privileged`<sup>Optional</sup> <a name="privileged" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.property.privileged"></a>
+
+```typescript
+public readonly privileged: boolean;
+```
+
+- *Type:* boolean
+- *Default:* undefined
+
+Run the container in privileged mode.
+
+---
+
+##### `readOnlyRootFilesystem`<sup>Optional</sup> <a name="readOnlyRootFilesystem" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.property.readOnlyRootFilesystem"></a>
+
+```typescript
+public readonly readOnlyRootFilesystem: boolean;
+```
+
+- *Type:* boolean
+- *Default:* undefined
+
+Mount the root filesystem as read-only.
+
+---
+
+##### `runAsGroup`<sup>Optional</sup> <a name="runAsGroup" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.property.runAsGroup"></a>
+
+```typescript
+public readonly runAsGroup: number;
+```
+
+- *Type:* number
+- *Default:* container default
+
+Run the container as a specific group ID.
+
+---
+
+##### `runAsNonRoot`<sup>Optional</sup> <a name="runAsNonRoot" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.property.runAsNonRoot"></a>
+
+```typescript
+public readonly runAsNonRoot: boolean;
+```
+
+- *Type:* boolean
+- *Default:* undefined
+
+Require the container to run as non-root.
+
+---
+
+##### `runAsUser`<sup>Optional</sup> <a name="runAsUser" id="@bluedynamics/cdk8s-plone.PloneSecurityContext.property.runAsUser"></a>
+
+```typescript
+public readonly runAsUser: number;
+```
+
+- *Type:* number
+- *Default:* container default
+
+Run the container as a specific user ID.
 
 ---
 

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -132,6 +132,14 @@ export interface PloneDeploymentOptions {
   readonly nodeSelector?: { [key: string]: string };
 
   /**
+   * Security context for the container.
+   * Use to set capabilities, run as non-root, read-only filesystem, etc.
+   * @example { capabilities: { add: ['SYS_PTRACE'] } }
+   * @default - no security context
+   */
+  readonly securityContext?: k8s.SecurityContext;
+
+  /**
    * Liveness probe configuration for the container.
    * @default - undefined (no liveness probe)
    */
@@ -197,6 +205,7 @@ export class PloneDeployment extends Construct {
       },
       livenessProbe: options.livenessProbe ?? undefined,
       readinessProbe: options.readinessProbe ?? undefined,
+      securityContext: options.securityContext,
     };
     const deploymentOptions: k8s.KubeDeploymentProps = {
       metadata: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Plone, PloneOptions, PloneBaseOptions, PloneVariant } from './plone';
+export { Plone, PloneOptions, PloneBaseOptions, PloneVariant, PloneSecurityContext, PloneCapabilities } from './plone';
 export { PloneHttpcache, PloneHttpcacheOptions, HttpcacheEnvVar, HttpcacheToleration } from './httpcache';
 export { PloneVinylCache, PloneVinylCacheOptions, VinylCacheToleration, VinylCacheBackend, VinylCacheBackendProbe } from './vinylcache';

--- a/src/plone.ts
+++ b/src/plone.ts
@@ -8,6 +8,72 @@ import { ServiceMonitor, ServiceMonitorSpecEndpointsTargetPort } from './imports
 import { PloneService } from './service';
 
 /**
+ * Linux capabilities to add or drop on a container.
+ */
+export interface PloneCapabilities {
+  /**
+   * Capabilities to add (e.g. 'SYS_PTRACE', 'NET_ADMIN').
+   * @default - no capabilities added
+   */
+  readonly add?: string[];
+
+  /**
+   * Capabilities to drop (e.g. 'ALL', 'NET_RAW').
+   * @default - no capabilities dropped
+   */
+  readonly drop?: string[];
+}
+
+/**
+ * Security context for a Plone container.
+ * Controls privilege and access settings.
+ */
+export interface PloneSecurityContext {
+  /**
+   * Linux capabilities to add or drop.
+   * @example { add: ['SYS_PTRACE'] }
+   * @default - no capability changes
+   */
+  readonly capabilities?: PloneCapabilities;
+
+  /**
+   * Run the container as a specific user ID.
+   * @default - container default
+   */
+  readonly runAsUser?: number;
+
+  /**
+   * Run the container as a specific group ID.
+   * @default - container default
+   */
+  readonly runAsGroup?: number;
+
+  /**
+   * Require the container to run as non-root.
+   * @default - undefined
+   */
+  readonly runAsNonRoot?: boolean;
+
+  /**
+   * Mount the root filesystem as read-only.
+   * @default - undefined
+   */
+  readonly readOnlyRootFilesystem?: boolean;
+
+  /**
+   * Allow privilege escalation for the container process.
+   * @default - undefined
+   */
+  readonly allowPrivilegeEscalation?: boolean;
+
+  /**
+   * Run the container in privileged mode.
+   * @default - undefined
+   */
+  readonly privileged?: boolean;
+}
+
+/**
  * Base options for Plone backend or frontend configuration.
  * These options control container image, replica count, resource limits,
  * environment variables, and health probes.
@@ -210,6 +276,14 @@ export interface PloneBaseOptions {
    * @default - no node selector
    */
   readonly nodeSelector?: { [key: string]: string };
+
+  /**
+   * Security context for the container.
+   * Use to set capabilities, run as non-root, read-only filesystem, etc.
+   * @example { capabilities: { add: ['SYS_PTRACE'] } }
+   * @default - no security context
+   */
+  readonly securityContext?: PloneSecurityContext;
 }
 /**
  * Plone deployment variants.
@@ -359,6 +433,7 @@ export class Plone extends Construct {
       annotations: backend.annotations,
       podAnnotations: backend.podAnnotations,
       nodeSelector: backend.nodeSelector,
+      securityContext: backend.securityContext as k8s.SecurityContext,
     };
 
     // Probing
@@ -451,6 +526,7 @@ export class Plone extends Construct {
         annotations: frontend.annotations,
         podAnnotations: frontend.podAnnotations,
         nodeSelector: frontend.nodeSelector,
+        securityContext: frontend.securityContext as k8s.SecurityContext,
       };
 
       // Probing

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -313,3 +313,63 @@ exports[`with-pdp 1`] = `
   },
 ]
 `;
+
+exports[`with-security-context 1`] = `
+[
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "-deployment",
+        "app.kubernetes.io/name": "undefined-deployment",
+      },
+      "name": "plone-with_security_context-deployment-c88cad2d",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-with_security_context-c85ae4da",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-with_security_context-c85ae4da",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/part-of": "plone",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [],
+              "envFrom": [],
+              "name": "with_security_context-container",
+              "resources": {
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "1Gi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "300Mi",
+                },
+              },
+              "securityContext": {
+                "capabilities": {
+                  "add": [
+                    "SYS_PTRACE",
+                  ],
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+]
+`;

--- a/test/__snapshots__/plone.test.ts.snap
+++ b/test/__snapshots__/plone.test.ts.snap
@@ -797,6 +797,239 @@ exports[`with nodeSelector for region affinity 1`] = `
 ]
 `;
 
+exports[`with securityContext for capabilities 1`] = `
+[
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "backend",
+        "app.kubernetes.io/name": "plone-backend-deployment",
+      },
+      "name": "app-plone-backend-deployment-c85baacf",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "app-plone-backend-c82290e6",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "app-plone-backend-c82290e6",
+            "app.kubernetes.io/component": "backend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-backend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [],
+              "envFrom": [],
+              "image": "plone/plone-backend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "backend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 8080,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+              "securityContext": {
+                "capabilities": {
+                  "add": [
+                    "SYS_PTRACE",
+                  ],
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "app-plone-backend-pdb-c8f00fdc",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "app-plone-backend-c82290e6",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-backend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "app-plone-backend-service-c8efef4c",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "backend-http",
+          "port": 8080,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": {
+        "app": "app-plone-backend-c82290e6",
+      },
+    },
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "frontend",
+        "app.kubernetes.io/name": "plone-frontend-deployment",
+      },
+      "name": "app-plone-frontend-deployment-c872e367",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "app-plone-frontend-c8d010d1",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "app-plone-frontend-c8d010d1",
+            "app.kubernetes.io/component": "frontend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-frontend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "RAZZLE_INTERNAL_API_PATH",
+                  "value": "http://app-plone-backend-service-c8efef4c:8080/Plone",
+                },
+              ],
+              "envFrom": [],
+              "image": "plone/plone-frontend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "frontend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 3000,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "1Gi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "app-plone-frontend-pdb-c82dd14e",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "app-plone-frontend-c8d010d1",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-frontend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "app-plone-frontend-service-c8f392cd",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "frontend-http",
+          "port": 3000,
+          "targetPort": 3000,
+        },
+      ],
+      "selector": {
+        "app": "app-plone-frontend-c8d010d1",
+      },
+    },
+  },
+]
+`;
+
 exports[`with-backend-servicemonitor 1`] = `
 [
   {

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -61,6 +61,23 @@ test('with-environment-valueFrom', () => {
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
+test('with-security-context', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'plone');
+
+  // WHEN
+  new PloneDeployment(chart, 'with_security_context', {
+    port: 8080,
+    securityContext: {
+      capabilities: { add: ['SYS_PTRACE'] },
+    },
+  });
+
+  // THEN
+  expect(Testing.synth(chart)).toMatchSnapshot();
+});
+
 test('with-environment-from-secret', () => {
   // GIVEN
   const app = Testing.app();

--- a/test/plone.test.ts
+++ b/test/plone.test.ts
@@ -101,6 +101,22 @@ test('with-both-servicemonitors', () => {
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
+test('with securityContext for capabilities', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'app');
+
+  // WHEN
+  new Plone(chart, 'plone', {
+    backend: {
+      securityContext: { capabilities: { add: ['SYS_PTRACE'] } },
+    },
+  });
+
+  // THEN
+  expect(Testing.synth(chart)).toMatchSnapshot();
+});
+
 test('with nodeSelector for region affinity', () => {
   // GIVEN
   const app = Testing.app();


### PR DESCRIPTION
## Summary

- Adds `securityContext` property to `PloneBaseOptions` for configuring container security settings (capabilities, runAsUser, runAsNonRoot, readOnlyRootFilesystem, etc.)
- Defines JSII-compatible `PloneSecurityContext` and `PloneCapabilities` interfaces (avoids cascading k8s type export issues)
- Wires through `PloneDeploymentOptions` → container spec for both backend and frontend

## Motivation

Tools like `py-spy` require `SYS_PTRACE` capability on the container. Until now there was no way to set this via the Plone construct.

## Usage

```typescript
new Plone(chart, 'plone', {
  backend: {
    securityContext: { capabilities: { add: ['SYS_PTRACE'] } },
  },
});
```

## Test plan

- [x] Snapshot test for `PloneDeployment` with securityContext
- [x] Snapshot test for `Plone` construct with securityContext on backend
- [x] All existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)