### PR TITLE
feat(vinylcache): expose shard director tuning (by, healthy, rampup, replicas)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1794,6 +1794,10 @@ const ploneVinylCacheOptions: PloneVinylCacheOptions = { ... }
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.replicas">replicas</a></code> | <code>number</code> | Number of Varnish pod replicas. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.requestCpu">requestCpu</a></code> | <code>string</code> | CPU request for Varnish pods. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.requestMemory">requestMemory</a></code> | <code>string</code> | Memory request for Varnish pods. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardBy">shardBy</a></code> | <code>string</code> | Shard director: what value is hashed for shard selection. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardHealthy">shardHealthy</a></code> | <code>string</code> | Shard director: which backends the director considers when selecting a shard. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardRampup">shardRampup</a></code> | <code>string</code> | Shard director: time after adding a backend before it receives its full share of traffic, preventing thundering-herd. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardReplicas">shardReplicas</a></code> | <code>number</code> | Shard director: number of Ketama replicas per backend in the hash ring. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.tolerations">tolerations</a></code> | <code><a href="#@bluedynamics/cdk8s-plone.VinylCacheToleration">VinylCacheToleration</a>[]</code> | Tolerations for the Varnish pods. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.vclBackendErrorSnippet">vclBackendErrorSnippet</a></code> | <code>string</code> | Custom VCL snippet for vcl_backend_error subroutine. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.vclBackendFetchSnippet">vclBackendFetchSnippet</a></code> | <code>string</code> | Custom VCL snippet for vcl_backend_fetch subroutine. |
@@ -1970,6 +1974,71 @@ public readonly requestMemory: string;
 - *Default:* '256Mi'
 
 Memory request for Varnish pods.
+
+---
+
+##### `shardBy`<sup>Optional</sup> <a name="shardBy" id="@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardBy"></a>
+
+```typescript
+public readonly shardBy: string;
+```
+
+- *Type:* string
+- *Default:* operator default ("HASH")
+
+Shard director: what value is hashed for shard selection.
+
+"HASH" uses the Varnish hash (default); "URL" uses the request URL.
+Only applied when director is "shard".
+Requires cloud-vinyl operator >= 0.4.2.
+
+---
+
+##### `shardHealthy`<sup>Optional</sup> <a name="shardHealthy" id="@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardHealthy"></a>
+
+```typescript
+public readonly shardHealthy: string;
+```
+
+- *Type:* string
+- *Default:* operator default ("CHOSEN")
+
+Shard director: which backends the director considers when selecting a shard.
+
+"CHOSEN" (default) only considers the chosen backend healthy; "ALL" requires all
+backends to be healthy.
+Only applied when director is "shard".
+Requires cloud-vinyl operator >= 0.4.2.
+
+---
+
+##### `shardRampup`<sup>Optional</sup> <a name="shardRampup" id="@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardRampup"></a>
+
+```typescript
+public readonly shardRampup: string;
+```
+
+- *Type:* string
+- *Default:* operator default ("30s")
+
+Shard director: time after adding a backend before it receives its full share of traffic, preventing thundering-herd.
+
+Only applied when director is "shard".
+
+---
+
+##### `shardReplicas`<sup>Optional</sup> <a name="shardReplicas" id="@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardReplicas"></a>
+
+```typescript
+public readonly shardReplicas: number;
+```
+
+- *Type:* number
+- *Default:* operator default (67)
+
+Shard director: number of Ketama replicas per backend in the hash ring.
+
+Only applied when director is "shard".
 
 ---
 

--- a/documentation/sources/how-to/deploy-with-vinyl-cache.md
+++ b/documentation/sources/how-to/deploy-with-vinyl-cache.md
@@ -82,6 +82,11 @@ new PloneVinylCache(chart, 'cache', {
 
 Invalidation is enabled by default (PURGE, BAN, xkey). Configure `plone.cachepurging` to point to the VinylCache invalidation proxy endpoint.
 
+:::{note}
+BAN-based invalidation requires **cloud-vinyl operator ≥ 0.4.2**. Earlier versions accept the spec but do not emit the BAN ACL / handler.
+Starting with 0.4.2 the operator's own pod IP is automatically added to the PURGE ACL, so purges from the operator itself work without additional configuration.
+:::
+
 To disable invalidation:
 
 ```typescript
@@ -90,6 +95,23 @@ new PloneVinylCache(chart, 'cache', {
   invalidation: false,
 });
 ```
+
+### Shard Director Tuning
+
+For shard-based load distribution (the default), you can fine-tune the consistent-hash behavior. These options require **cloud-vinyl ≥ 0.4.2** to be honored by the generated VCL.
+
+```typescript
+new PloneVinylCache(chart, 'cache', {
+  plone: plone,
+  director: 'shard',
+  shardBy: 'URL',        // hash the request URL instead of Varnish's hash
+  shardHealthy: 'ALL',   // require all backends healthy (vs. only "CHOSEN")
+  shardRampup: '45s',    // warm-up window for newly added backends
+  shardReplicas: 128,    // Ketama replicas per backend
+});
+```
+
+Shard options are ignored for non-shard directors (`round_robin`, `random`, `hash`).
 
 ## Migrating from PloneHttpcache
 

--- a/src/vinylcache.ts
+++ b/src/vinylcache.ts
@@ -4,6 +4,8 @@ import { Names } from 'cdk8s';
 import { Construct } from 'constructs';
 import {
   VinylCache,
+  VinylCacheSpecDirectorShardBy,
+  VinylCacheSpecDirectorShardHealthy,
   VinylCacheSpecDirectorType,
   VinylCacheSpecResourcesLimits,
   VinylCacheSpecResourcesRequests,
@@ -168,6 +170,40 @@ export interface PloneVinylCacheOptions {
    * @default 'shard'
    */
   readonly director?: string;
+
+  /**
+   * Shard director: what value is hashed for shard selection.
+   * "HASH" uses the Varnish hash (default); "URL" uses the request URL.
+   * Only applied when director is "shard".
+   * Requires cloud-vinyl operator >= 0.4.2.
+   * @default - operator default ("HASH")
+   */
+  readonly shardBy?: string;
+
+  /**
+   * Shard director: which backends the director considers when selecting a shard.
+   * "CHOSEN" (default) only considers the chosen backend healthy; "ALL" requires all
+   * backends to be healthy.
+   * Only applied when director is "shard".
+   * Requires cloud-vinyl operator >= 0.4.2.
+   * @default - operator default ("CHOSEN")
+   */
+  readonly shardHealthy?: string;
+
+  /**
+   * Shard director: time after adding a backend before it receives its full share of
+   * traffic, preventing thundering-herd.
+   * Only applied when director is "shard".
+   * @default - operator default ("30s")
+   */
+  readonly shardRampup?: string;
+
+  /**
+   * Shard director: number of Ketama replicas per backend in the hash ring.
+   * Only applied when director is "shard".
+   * @default - operator default (67)
+   */
+  readonly shardReplicas?: number;
 
   /**
    * Custom VCL snippet for vcl_recv subroutine.
@@ -335,6 +371,32 @@ export class PloneVinylCache extends Construct {
         directorType = VinylCacheSpecDirectorType.SHARD;
     }
 
+    // Shard director tuning: only honored by the operator when director type is "shard".
+    // Emit the shard block only for shard directors so manifests stay minimal.
+    let shardSpec: {
+      by?: VinylCacheSpecDirectorShardBy;
+      healthy?: VinylCacheSpecDirectorShardHealthy;
+      rampup?: string;
+      replicas?: number;
+    } | undefined;
+    if (directorType === VinylCacheSpecDirectorType.SHARD &&
+        (options.shardBy || options.shardHealthy || options.shardRampup || options.shardReplicas !== undefined)) {
+      let shardBy: VinylCacheSpecDirectorShardBy | undefined;
+      if (options.shardBy === 'URL') shardBy = VinylCacheSpecDirectorShardBy.URL;
+      else if (options.shardBy === 'HASH') shardBy = VinylCacheSpecDirectorShardBy.HASH;
+
+      let shardHealthy: VinylCacheSpecDirectorShardHealthy | undefined;
+      if (options.shardHealthy === 'ALL') shardHealthy = VinylCacheSpecDirectorShardHealthy.ALL;
+      else if (options.shardHealthy === 'CHOSEN') shardHealthy = VinylCacheSpecDirectorShardHealthy.CHOSEN;
+
+      shardSpec = {
+        by: shardBy,
+        healthy: shardHealthy,
+        rampup: options.shardRampup,
+        replicas: options.shardReplicas,
+      };
+    }
+
     // Load default VCL snippets
     const vclRecv = options.vclRecvSnippet ??
       fs.readFileSync(path.join(__dirname, 'config', 'plone-vinyl-recv.vcl'), 'utf8');
@@ -406,7 +468,7 @@ export class PloneVinylCache extends Construct {
         replicas,
         image: options.image ?? 'varnish:7.6',
         backends,
-        director: { type: directorType },
+        director: { type: directorType, shard: shardSpec },
         vcl: {
           snippets: {
             vclRecv: vclRecv,

--- a/test/__snapshots__/vinylcache.test.ts.snap
+++ b/test/__snapshots__/vinylcache.test.ts.snap
@@ -1612,6 +1612,369 @@ if (req.http.Cookie) {
 ]
 `;
 
+exports[`with full shard tuning (healthy, rampup, replicas) 1`] = `
+[
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "backend",
+        "app.kubernetes.io/name": "plone-backend-deployment",
+      },
+      "name": "plone-backend-deployment-c8eff9e3",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-backend-c8acbe0a",
+            "app.kubernetes.io/component": "backend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-backend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [],
+              "envFrom": [],
+              "image": "plone/plone-backend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "backend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 8080,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-pdb-c8b4facc",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-backend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-service-c87548c4",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "backend-http",
+          "port": 8080,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": {
+        "app": "plone-backend-c8acbe0a",
+      },
+    },
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "frontend",
+        "app.kubernetes.io/name": "plone-frontend-deployment",
+      },
+      "name": "plone-frontend-deployment-c8fc8a4d",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-frontend-c88fef5c",
+            "app.kubernetes.io/component": "frontend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-frontend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "RAZZLE_INTERNAL_API_PATH",
+                  "value": "http://plone-backend-service-c87548c4:8080/Plone",
+                },
+              ],
+              "envFrom": [],
+              "image": "plone/plone-frontend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "frontend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 3000,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "1Gi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-pdb-c8e94afa",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-frontend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-service-c87c3840",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "frontend-http",
+          "port": 3000,
+          "targetPort": 3000,
+        },
+      ],
+      "selector": {
+        "app": "plone-frontend-c88fef5c",
+      },
+    },
+  },
+  {
+    "apiVersion": "vinyl.bluedynamics.eu/v1alpha1",
+    "kind": "VinylCache",
+    "metadata": {
+      "name": "plone-test-vinylcache-c80a8790",
+    },
+    "spec": {
+      "backends": [
+        {
+          "name": "plone_backend",
+          "port": 8080,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/ok",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-backend-service-c87548c4",
+          },
+        },
+        {
+          "name": "plone_frontend",
+          "port": 3000,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-frontend-service-c87c3840",
+          },
+        },
+      ],
+      "director": {
+        "shard": {
+          "by": "HASH",
+          "healthy": "ALL",
+          "rampup": "45s",
+          "replicas": 128,
+        },
+        "type": "shard",
+      },
+      "image": "varnish:7.6",
+      "invalidation": {
+        "ban": {
+          "enabled": true,
+        },
+        "purge": {
+          "enabled": true,
+        },
+        "xkey": {
+          "enabled": true,
+        },
+      },
+      "replicas": 2,
+      "resources": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "512Mi",
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi",
+        },
+      },
+      "vcl": {
+        "snippets": {
+          "vclBackendResponse": "# Plone vcl_backend_response snippet for cloud-vinyl
+# Injected into vcl_backend_response
+
+# Remove Set-Cookie from static resources
+if (bereq.url ~ "\\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js|svg|woff|woff2|ttf|eot)(\\?.*)?$") {
+  unset beresp.http.Set-Cookie;
+}
+
+# Don't cache responses with Set-Cookie
+if (beresp.http.Set-Cookie) {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Don't cache private responses
+if (beresp.http.Cache-Control ~ "private") {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Default TTL for responses without Cache-Control
+if (!beresp.http.Cache-Control) {
+  set beresp.ttl = 30s;
+  set beresp.grace = 60s;
+}
+",
+          "vclRecv": "# Plone vcl_recv snippet for cloud-vinyl
+# Injected into vcl_recv after routing, before return()
+
+# Handle PURGE requests from Kubernetes network
+if (req.method == "PURGE") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  return (purge);
+}
+
+# Handle BAN requests
+if (req.method == "BAN") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  ban("obj.http.x-url ~ " + req.http.x-ban-url +
+      " && obj.http.x-host ~ " + req.http.x-ban-host);
+  return (synth(200, "Ban added"));
+}
+
+# Detect authenticated requests
+if (req.http.Cookie ~ "__ac" || req.http.Authorization) {
+  set req.http.X-Plone-Auth = "true";
+  return (pass);
+}
+
+# Remove tracking cookies to improve cache hit rate
+if (req.http.Cookie) {
+  set req.http.Cookie = regsuball(req.http.Cookie, "(^|;\\s*)(_ga[^=]*|_gid|_gat|__utm[a-z]+|_hj[a-z]+|_fbp|_fbc)=[^;]*", "");
+  set req.http.Cookie = regsuball(req.http.Cookie, "^;\\s*", "");
+  if (req.http.Cookie ~ "^\\s*$") {
+    unset req.http.Cookie;
+  }
+}
+",
+        },
+      },
+    },
+  },
+]
+`;
+
 exports[`with invalidation disabled 1`] = `
 [
   {
@@ -3316,6 +3679,366 @@ exports[`with shard director 1`] = `
       ],
       "director": {
         "type": "round_robin",
+      },
+      "image": "varnish:7.6",
+      "invalidation": {
+        "ban": {
+          "enabled": true,
+        },
+        "purge": {
+          "enabled": true,
+        },
+        "xkey": {
+          "enabled": true,
+        },
+      },
+      "replicas": 2,
+      "resources": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "512Mi",
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi",
+        },
+      },
+      "vcl": {
+        "snippets": {
+          "vclBackendResponse": "# Plone vcl_backend_response snippet for cloud-vinyl
+# Injected into vcl_backend_response
+
+# Remove Set-Cookie from static resources
+if (bereq.url ~ "\\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js|svg|woff|woff2|ttf|eot)(\\?.*)?$") {
+  unset beresp.http.Set-Cookie;
+}
+
+# Don't cache responses with Set-Cookie
+if (beresp.http.Set-Cookie) {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Don't cache private responses
+if (beresp.http.Cache-Control ~ "private") {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Default TTL for responses without Cache-Control
+if (!beresp.http.Cache-Control) {
+  set beresp.ttl = 30s;
+  set beresp.grace = 60s;
+}
+",
+          "vclRecv": "# Plone vcl_recv snippet for cloud-vinyl
+# Injected into vcl_recv after routing, before return()
+
+# Handle PURGE requests from Kubernetes network
+if (req.method == "PURGE") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  return (purge);
+}
+
+# Handle BAN requests
+if (req.method == "BAN") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  ban("obj.http.x-url ~ " + req.http.x-ban-url +
+      " && obj.http.x-host ~ " + req.http.x-ban-host);
+  return (synth(200, "Ban added"));
+}
+
+# Detect authenticated requests
+if (req.http.Cookie ~ "__ac" || req.http.Authorization) {
+  set req.http.X-Plone-Auth = "true";
+  return (pass);
+}
+
+# Remove tracking cookies to improve cache hit rate
+if (req.http.Cookie) {
+  set req.http.Cookie = regsuball(req.http.Cookie, "(^|;\\s*)(_ga[^=]*|_gid|_gat|__utm[a-z]+|_hj[a-z]+|_fbp|_fbc)=[^;]*", "");
+  set req.http.Cookie = regsuball(req.http.Cookie, "^;\\s*", "");
+  if (req.http.Cookie ~ "^\\s*$") {
+    unset req.http.Cookie;
+  }
+}
+",
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`with shard director and shardBy URL 1`] = `
+[
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "backend",
+        "app.kubernetes.io/name": "plone-backend-deployment",
+      },
+      "name": "plone-backend-deployment-c8eff9e3",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-backend-c8acbe0a",
+            "app.kubernetes.io/component": "backend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-backend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [],
+              "envFrom": [],
+              "image": "plone/plone-backend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "backend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 8080,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-pdb-c8b4facc",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-backend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-service-c87548c4",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "backend-http",
+          "port": 8080,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": {
+        "app": "plone-backend-c8acbe0a",
+      },
+    },
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "frontend",
+        "app.kubernetes.io/name": "plone-frontend-deployment",
+      },
+      "name": "plone-frontend-deployment-c8fc8a4d",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-frontend-c88fef5c",
+            "app.kubernetes.io/component": "frontend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-frontend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "RAZZLE_INTERNAL_API_PATH",
+                  "value": "http://plone-backend-service-c87548c4:8080/Plone",
+                },
+              ],
+              "envFrom": [],
+              "image": "plone/plone-frontend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "frontend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 3000,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "1Gi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-pdb-c8e94afa",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-frontend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-service-c87c3840",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "frontend-http",
+          "port": 3000,
+          "targetPort": 3000,
+        },
+      ],
+      "selector": {
+        "app": "plone-frontend-c88fef5c",
+      },
+    },
+  },
+  {
+    "apiVersion": "vinyl.bluedynamics.eu/v1alpha1",
+    "kind": "VinylCache",
+    "metadata": {
+      "name": "plone-test-vinylcache-c80a8790",
+    },
+    "spec": {
+      "backends": [
+        {
+          "name": "plone_backend",
+          "port": 8080,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/ok",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-backend-service-c87548c4",
+          },
+        },
+        {
+          "name": "plone_frontend",
+          "port": 3000,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-frontend-service-c87c3840",
+          },
+        },
+      ],
+      "director": {
+        "shard": {
+          "by": "URL",
+        },
+        "type": "shard",
       },
       "image": "varnish:7.6",
       "invalidation": {

--- a/test/vinylcache.test.ts
+++ b/test/vinylcache.test.ts
@@ -212,6 +212,65 @@ test('with nodeSelector and tolerations', () => {
   expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
+test('with shard director and shardBy URL', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'plone');
+  const plone = new Plone(chart, 'plone');
+
+  // WHEN
+  new PloneVinylCache(chart, 'test', {
+    plone,
+    director: 'shard',
+    shardBy: 'URL',
+  });
+
+  // THEN
+  expect(Testing.synth(chart)).toMatchSnapshot();
+});
+
+test('with full shard tuning (healthy, rampup, replicas)', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'plone');
+  const plone = new Plone(chart, 'plone');
+
+  // WHEN
+  new PloneVinylCache(chart, 'test', {
+    plone,
+    director: 'shard',
+    shardBy: 'HASH',
+    shardHealthy: 'ALL',
+    shardRampup: '45s',
+    shardReplicas: 128,
+  });
+
+  // THEN
+  expect(Testing.synth(chart)).toMatchSnapshot();
+});
+
+test('shard options ignored when director is non-shard', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'plone');
+  const plone = new Plone(chart, 'plone');
+
+  // WHEN
+  new PloneVinylCache(chart, 'test', {
+    plone,
+    director: 'round_robin',
+    shardBy: 'URL',
+    shardHealthy: 'ALL',
+  });
+
+  // THEN - emitted manifest must not contain a shard block
+  const manifest = Testing.synth(chart);
+  const vc = manifest.find(r => r.kind === 'VinylCache');
+  expect(vc).toBeDefined();
+  expect(vc.spec.director.type).toBe('round_robin');
+  expect(vc.spec.director.shard).toBeUndefined();
+});
+
 test('exposes vinylCacheServiceName', () => {
   // GIVEN
   const app = Testing.app();


### PR DESCRIPTION
## Summary

- Expose `shardBy`, `shardHealthy`, `shardRampup`, `shardReplicas` on `PloneVinylCacheOptions`, wired into `spec.director.shard` on the `VinylCache` CR
- Shard block is emitted only when `director` resolves to `shard` and at least one shard option is set, so existing manifests are unchanged
- Document that BAN-based invalidation (already exposed via `invalidation: true`) requires **cloud-vinyl operator ≥ 0.4.2** to actually emit BAN ACL + handler

## Context

cloud-vinyl 0.4.2 ([release](https://github.com/bluedynamics/cloud-vinyl/releases/tag/v0.4.2)) shipped three operator-side improvements without CRD changes:

- `feat/operator-ip-in-acl` — operator pod IP auto-added to PURGE ACL (transparent, nothing to do here)
- `feat/ban-support` — BAN ACL + handler emission when `spec.invalidation.ban.enabled` is set (already wired in this construct; documented now)
- `feat/shard-by-healthy-plumbing` — `spec.director.shard.{by,healthy}` now honored in generated VCL (this PR exposes them + `rampup` + `replicas`)

CRD SHA is identical between v0.4.1 and v0.4.2, so no `import:vinylcache` regeneration is required.

## Test plan

- [x] New unit test: `shardBy: 'URL'` produces `spec.director.shard.by = "URL"`
- [x] New unit test: `shardHealthy`, `shardRampup`, `shardReplicas` all surface in the manifest
- [x] New unit test: shard options are suppressed when director is `round_robin` (asserted against synthesized manifest, not snapshot)
- [x] `npx projen test` — 41/41 pass
- [x] `npx projen build` — jsii packaging succeeds for js + python
- [ ] Downstream smoke-test in `cdk8s-plone-example` against cloud-vinyl 0.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)