### PR TITLE
feat(vinylcache): expose spec.storage on PloneVinylCache

### DIFF
--- a/API.md
+++ b/API.md
@@ -1798,6 +1798,7 @@ const ploneVinylCacheOptions: PloneVinylCacheOptions = { ... }
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardHealthy">shardHealthy</a></code> | <code>string</code> | Shard director: which backends the director considers when selecting a shard. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardRampup">shardRampup</a></code> | <code>string</code> | Shard director: time after adding a backend before it receives its full share of traffic, preventing thundering-herd. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.shardReplicas">shardReplicas</a></code> | <code>number</code> | Shard director: number of Ketama replicas per backend in the hash ring. |
+| <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.storage">storage</a></code> | <code><a href="#@bluedynamics/cdk8s-plone.VinylCacheStorage">VinylCacheStorage</a>[]</code> | Varnish storage backends (`spec.storage`). |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.tolerations">tolerations</a></code> | <code><a href="#@bluedynamics/cdk8s-plone.VinylCacheToleration">VinylCacheToleration</a>[]</code> | Tolerations for the Varnish pods. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.vclBackendErrorSnippet">vclBackendErrorSnippet</a></code> | <code>string</code> | Custom VCL snippet for vcl_backend_error subroutine. |
 | <code><a href="#@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.vclBackendFetchSnippet">vclBackendFetchSnippet</a></code> | <code>string</code> | Custom VCL snippet for vcl_backend_fetch subroutine. |
@@ -2041,6 +2042,31 @@ Shard director: number of Ketama replicas per backend in the hash ring.
 Only applied when director is "shard".
 
 ---
+
+##### `storage`<sup>Optional</sup> <a name="storage" id="@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.storage"></a>
+
+```typescript
+public readonly storage: VinylCacheStorage[];
+```
+
+- *Type:* <a href="#@bluedynamics/cdk8s-plone.VinylCacheStorage">VinylCacheStorage</a>[]
+- *Default:* no storage configured; operator uses varnishd default (~100MB malloc)
+
+Varnish storage backends (`spec.storage`).
+
+Each entry becomes a `-s <name>=<type>,<options>` argument to varnishd.
+If omitted, the operator ships varnishd with its stock default (~100 MB
+malloc) — almost always too small. Set an explicit malloc size at least
+matching the pod's memory request to use the allocated memory for caching.
+
+---
+
+*Example*
+
+```typescript
+storage: [{ name: 's0', type: 'malloc', size: '1Gi' }]
+```
+
 
 ##### `tolerations`<sup>Optional</sup> <a name="tolerations" id="@bluedynamics/cdk8s-plone.PloneVinylCacheOptions.property.tolerations"></a>
 
@@ -2431,6 +2457,92 @@ public readonly window: number;
 - *Default:* 10
 
 Number of most recent probes to consider.
+
+---
+
+### VinylCacheStorage <a name="VinylCacheStorage" id="@bluedynamics/cdk8s-plone.VinylCacheStorage"></a>
+
+A Varnish storage backend configuration.
+
+Maps to `spec.storage[]` on the VinylCache CRD. The operator emits one
+`-s <name>=<type>,<options>` argument per entry to varnishd.
+
+Without any storage entry the operator falls back to the varnishd default
+(~100 MB malloc), which is almost always too small for real workloads.
+
+#### Initializer <a name="Initializer" id="@bluedynamics/cdk8s-plone.VinylCacheStorage.Initializer"></a>
+
+```typescript
+import { VinylCacheStorage } from '@bluedynamics/cdk8s-plone'
+
+const vinylCacheStorage: VinylCacheStorage = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@bluedynamics/cdk8s-plone.VinylCacheStorage.property.name">name</a></code> | <code>string</code> | Internal storage identifier used in the varnishd `-s` argument. |
+| <code><a href="#@bluedynamics/cdk8s-plone.VinylCacheStorage.property.type">type</a></code> | <code>string</code> | Storage backend type. |
+| <code><a href="#@bluedynamics/cdk8s-plone.VinylCacheStorage.property.path">path</a></code> | <code>string</code> | Filesystem path for file-type storage. |
+| <code><a href="#@bluedynamics/cdk8s-plone.VinylCacheStorage.property.size">size</a></code> | <code>string</code> | Storage allocation as a Kubernetes resource quantity (e.g. "1Gi", "500M"). Required for malloc; required for file. |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@bluedynamics/cdk8s-plone.VinylCacheStorage.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+Internal storage identifier used in the varnishd `-s` argument.
+
+Must be unique within the VinylCache and match `^[a-zA-Z][a-zA-Z0-9_]*$`.
+
+---
+
+##### `type`<sup>Required</sup> <a name="type" id="@bluedynamics/cdk8s-plone.VinylCacheStorage.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+Storage backend type.
+
+Only "malloc" and "file" are permitted by the
+admission webhook.
+
+---
+
+##### `path`<sup>Optional</sup> <a name="path" id="@bluedynamics/cdk8s-plone.VinylCacheStorage.property.path"></a>
+
+```typescript
+public readonly path: string;
+```
+
+- *Type:* string
+- *Default:* required for type "file"
+
+Filesystem path for file-type storage.
+
+Ignored for malloc.
+
+---
+
+##### `size`<sup>Optional</sup> <a name="size" id="@bluedynamics/cdk8s-plone.VinylCacheStorage.property.size"></a>
+
+```typescript
+public readonly size: string;
+```
+
+- *Type:* string
+- *Default:* required for both malloc and file
+
+Storage allocation as a Kubernetes resource quantity (e.g. "1Gi", "500M"). Required for malloc; required for file.
 
 ---
 

--- a/documentation/sources/how-to/deploy-with-vinyl-cache.md
+++ b/documentation/sources/how-to/deploy-with-vinyl-cache.md
@@ -66,6 +66,33 @@ kubectl get pods -n <namespace> -l app.kubernetes.io/managed-by=cloud-vinyl
 
 ## Customization
 
+### Sizing the Cache Storage
+
+Without an explicit `storage` entry, the operator ships varnishd with its
+stock default (~100 MB malloc) — almost always too small. Set a malloc size
+below the pod's memory limit, leaving headroom for varnishd overhead:
+
+```typescript
+new PloneVinylCache(chart, 'cache', {
+  plone: plone,
+  requestMemory: '512Mi',
+  limitMemory: '2Gi',
+  storage: [
+    { name: 's0', type: 'malloc', size: '1500M' },
+  ],
+});
+```
+
+For larger working sets you can combine an in-memory tier with a file-backed
+tier (requires a writable volume mount at the given path):
+
+```typescript
+storage: [
+  { name: 'mem', type: 'malloc', size: '500M' },
+  { name: 'disk', type: 'file', path: '/var/lib/varnish/disk.bin', size: '10Gi' },
+]
+```
+
 ### Custom VCL
 
 Override the default Plone VCL snippets for custom caching logic:

--- a/documentation/sources/reference/configuration-options.md
+++ b/documentation/sources/reference/configuration-options.md
@@ -307,12 +307,22 @@ Requires the [cloud-vinyl operator](https://github.com/bluedynamics/cloud-vinyl)
 | `limitCpu` | `string` | No | `500m` | CPU limit |
 | `requestMemory` | `string` | No | `256Mi` | Memory request |
 | `limitMemory` | `string` | No | `512Mi` | Memory limit |
+| `storage` | `VinylCacheStorage[]` | No | - | Varnish storage backends. If omitted, the operator falls back to the varnishd default (~100 MB malloc), which is almost always too small. |
 | `director` | `string` | No | `shard` | Director type: shard, round_robin, random, hash |
 | `vclRecvSnippet` | `string` | No | built-in | Custom VCL snippet for vcl_recv |
 | `vclBackendResponseSnippet` | `string` | No | built-in | Custom VCL snippet for vcl_backend_response |
 | `invalidation` | `boolean` | No | `true` | Enable PURGE/BAN/xkey cache invalidation |
 | `monitoring` | `boolean` | No | `false` | Enable Prometheus metrics and ServiceMonitor |
 | `tolerations` | `VinylCacheToleration[]` | No | - | Node tolerations for Varnish pods |
+
+**`VinylCacheStorage` fields:**
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | Internal storage identifier (must match `^[a-zA-Z][a-zA-Z0-9_]*$`) |
+| `type` | `'malloc' \| 'file'` | Yes | Storage backend type |
+| `size` | `string` | Yes | Kubernetes resource quantity (e.g. `"1Gi"`, `"500M"`) |
+| `path` | `string` | for `file` | Filesystem path for file-type storage |
 
 **Example:**
 ```typescript
@@ -342,6 +352,19 @@ new PloneVinylCache(chart, 'cache', {
   `,
 });
 ```
+
+**Storage sizing:**
+```typescript
+new PloneVinylCache(chart, 'cache', {
+  plone: ploneInstance,
+  limitMemory: '2Gi',
+  storage: [
+    { name: 's0', type: 'malloc', size: '1500M' },
+  ],
+});
+```
+
+Without an explicit `storage` entry, varnishd runs with its stock default (~100 MB malloc) regardless of the container's memory limit. Size malloc storage below the pod's memory limit to leave headroom for varnishd overhead and transient allocations.
 
 **vs PloneHttpcache:**
 - `PloneHttpcache` deploys Varnish via mittwald Helm chart (self-contained, no operator needed)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { Plone, PloneOptions, PloneBaseOptions, PloneVariant, PloneSecurityContext, PloneCapabilities } from './plone';
 export { PloneHttpcache, PloneHttpcacheOptions, HttpcacheEnvVar, HttpcacheToleration } from './httpcache';
-export { PloneVinylCache, PloneVinylCacheOptions, VinylCacheToleration, VinylCacheBackend, VinylCacheBackendProbe } from './vinylcache';
+export { PloneVinylCache, PloneVinylCacheOptions, VinylCacheToleration, VinylCacheBackend, VinylCacheBackendProbe, VinylCacheStorage } from './vinylcache';

--- a/src/vinylcache.ts
+++ b/src/vinylcache.ts
@@ -9,6 +9,9 @@ import {
   VinylCacheSpecDirectorType,
   VinylCacheSpecResourcesLimits,
   VinylCacheSpecResourcesRequests,
+  VinylCacheSpecStorage,
+  VinylCacheSpecStorageSize,
+  VinylCacheSpecStorageType,
 } from './imports/vinyl.bluedynamics.eu';
 import { Plone } from './plone';
 
@@ -83,6 +86,42 @@ export interface VinylCacheBackend {
    * @default - operator default
    */
   readonly weight?: number;
+}
+
+/**
+ * A Varnish storage backend configuration.
+ *
+ * Maps to `spec.storage[]` on the VinylCache CRD. The operator emits one
+ * `-s <name>=<type>,<options>` argument per entry to varnishd.
+ *
+ * Without any storage entry the operator falls back to the varnishd default
+ * (~100 MB malloc), which is almost always too small for real workloads.
+ */
+export interface VinylCacheStorage {
+  /**
+   * Internal storage identifier used in the varnishd `-s` argument.
+   * Must be unique within the VinylCache and match `^[a-zA-Z][a-zA-Z0-9_]*$`.
+   */
+  readonly name: string;
+
+  /**
+   * Storage backend type. Only "malloc" and "file" are permitted by the
+   * admission webhook.
+   */
+  readonly type: 'malloc' | 'file';
+
+  /**
+   * Storage allocation as a Kubernetes resource quantity (e.g. "1Gi", "500M").
+   * Required for malloc; required for file.
+   * @default - required for both malloc and file
+   */
+  readonly size?: string;
+
+  /**
+   * Filesystem path for file-type storage. Ignored for malloc.
+   * @default - required for type "file"
+   */
+  readonly path?: string;
 }
 
 /**
@@ -164,6 +203,20 @@ export interface PloneVinylCacheOptions {
    * @default '512Mi'
    */
   readonly limitMemory?: string;
+
+  /**
+   * Varnish storage backends (`spec.storage`).
+   *
+   * Each entry becomes a `-s <name>=<type>,<options>` argument to varnishd.
+   * If omitted, the operator ships varnishd with its stock default (~100 MB
+   * malloc) — almost always too small. Set an explicit malloc size at least
+   * matching the pod's memory request to use the allocated memory for caching.
+   *
+   * @default - no storage configured; operator uses varnishd default (~100MB malloc)
+   * @example
+   * storage: [{ name: 's0', type: 'malloc', size: '1Gi' }]
+   */
+  readonly storage?: VinylCacheStorage[];
 
   /**
    * Director type for load distribution.
@@ -463,12 +516,20 @@ export class PloneVinylCache extends Construct {
       }
     }
 
+    const storage: VinylCacheSpecStorage[] | undefined = options.storage?.map(s => ({
+      name: s.name,
+      type: s.type === 'file' ? VinylCacheSpecStorageType.FILE : VinylCacheSpecStorageType.MALLOC,
+      size: s.size !== undefined ? VinylCacheSpecStorageSize.fromString(s.size) : undefined,
+      path: s.path,
+    }));
+
     const vinylCache = new VinylCache(this, 'vinylcache', {
       spec: {
         replicas,
         image: options.image ?? 'varnish:7.6',
         backends,
         director: { type: directorType, shard: shardSpec },
+        storage,
         vcl: {
           snippets: {
             vclRecv: vclRecv,

--- a/test/__snapshots__/vinylcache.test.ts.snap
+++ b/test/__snapshots__/vinylcache.test.ts.snap
@@ -4134,6 +4134,740 @@ if (req.http.Cookie) {
 ]
 `;
 
+exports[`with storage file + malloc 1`] = `
+[
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "backend",
+        "app.kubernetes.io/name": "plone-backend-deployment",
+      },
+      "name": "plone-backend-deployment-c8eff9e3",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-backend-c8acbe0a",
+            "app.kubernetes.io/component": "backend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-backend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [],
+              "envFrom": [],
+              "image": "plone/plone-backend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "backend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 8080,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-pdb-c8b4facc",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-backend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-service-c87548c4",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "backend-http",
+          "port": 8080,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": {
+        "app": "plone-backend-c8acbe0a",
+      },
+    },
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "frontend",
+        "app.kubernetes.io/name": "plone-frontend-deployment",
+      },
+      "name": "plone-frontend-deployment-c8fc8a4d",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-frontend-c88fef5c",
+            "app.kubernetes.io/component": "frontend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-frontend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "RAZZLE_INTERNAL_API_PATH",
+                  "value": "http://plone-backend-service-c87548c4:8080/Plone",
+                },
+              ],
+              "envFrom": [],
+              "image": "plone/plone-frontend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "frontend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 3000,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "1Gi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-pdb-c8e94afa",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-frontend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-service-c87c3840",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "frontend-http",
+          "port": 3000,
+          "targetPort": 3000,
+        },
+      ],
+      "selector": {
+        "app": "plone-frontend-c88fef5c",
+      },
+    },
+  },
+  {
+    "apiVersion": "vinyl.bluedynamics.eu/v1alpha1",
+    "kind": "VinylCache",
+    "metadata": {
+      "name": "plone-test-vinylcache-c80a8790",
+    },
+    "spec": {
+      "backends": [
+        {
+          "name": "plone_backend",
+          "port": 8080,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/ok",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-backend-service-c87548c4",
+          },
+        },
+        {
+          "name": "plone_frontend",
+          "port": 3000,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-frontend-service-c87c3840",
+          },
+        },
+      ],
+      "director": {
+        "type": "shard",
+      },
+      "image": "varnish:7.6",
+      "invalidation": {
+        "ban": {
+          "enabled": true,
+        },
+        "purge": {
+          "enabled": true,
+        },
+        "xkey": {
+          "enabled": true,
+        },
+      },
+      "replicas": 2,
+      "resources": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "512Mi",
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi",
+        },
+      },
+      "storage": [
+        {
+          "name": "mem",
+          "size": "500M",
+          "type": "malloc",
+        },
+        {
+          "name": "disk",
+          "path": "/var/lib/varnish/disk.bin",
+          "size": "5Gi",
+          "type": "file",
+        },
+      ],
+      "vcl": {
+        "snippets": {
+          "vclBackendResponse": "# Plone vcl_backend_response snippet for cloud-vinyl
+# Injected into vcl_backend_response
+
+# Remove Set-Cookie from static resources
+if (bereq.url ~ "\\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js|svg|woff|woff2|ttf|eot)(\\?.*)?$") {
+  unset beresp.http.Set-Cookie;
+}
+
+# Don't cache responses with Set-Cookie
+if (beresp.http.Set-Cookie) {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Don't cache private responses
+if (beresp.http.Cache-Control ~ "private") {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Default TTL for responses without Cache-Control
+if (!beresp.http.Cache-Control) {
+  set beresp.ttl = 30s;
+  set beresp.grace = 60s;
+}
+",
+          "vclRecv": "# Plone vcl_recv snippet for cloud-vinyl
+# Injected into vcl_recv after routing, before return()
+
+# Handle PURGE requests from Kubernetes network
+if (req.method == "PURGE") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  return (purge);
+}
+
+# Handle BAN requests
+if (req.method == "BAN") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  ban("obj.http.x-url ~ " + req.http.x-ban-url +
+      " && obj.http.x-host ~ " + req.http.x-ban-host);
+  return (synth(200, "Ban added"));
+}
+
+# Detect authenticated requests
+if (req.http.Cookie ~ "__ac" || req.http.Authorization) {
+  set req.http.X-Plone-Auth = "true";
+  return (pass);
+}
+
+# Remove tracking cookies to improve cache hit rate
+if (req.http.Cookie) {
+  set req.http.Cookie = regsuball(req.http.Cookie, "(^|;\\s*)(_ga[^=]*|_gid|_gat|__utm[a-z]+|_hj[a-z]+|_fbp|_fbc)=[^;]*", "");
+  set req.http.Cookie = regsuball(req.http.Cookie, "^;\\s*", "");
+  if (req.http.Cookie ~ "^\\s*$") {
+    unset req.http.Cookie;
+  }
+}
+",
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`with storage malloc 1`] = `
+[
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "backend",
+        "app.kubernetes.io/name": "plone-backend-deployment",
+      },
+      "name": "plone-backend-deployment-c8eff9e3",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-backend-c8acbe0a",
+            "app.kubernetes.io/component": "backend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-backend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [],
+              "envFrom": [],
+              "image": "plone/plone-backend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "backend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 8080,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "512Mi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-pdb-c8b4facc",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-backend-c8acbe0a",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-backend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-backend-service-c87548c4",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "backend-http",
+          "port": 8080,
+          "targetPort": 8080,
+        },
+      ],
+      "selector": {
+        "app": "plone-backend-c8acbe0a",
+      },
+    },
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "frontend",
+        "app.kubernetes.io/name": "plone-frontend-deployment",
+      },
+      "name": "plone-frontend-deployment-c8fc8a4d",
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "plone-frontend-c88fef5c",
+            "app.kubernetes.io/component": "frontend",
+            "app.kubernetes.io/managed-by": "cdk8s-plone",
+            "app.kubernetes.io/name": "plone-frontend",
+            "app.kubernetes.io/part-of": "plone",
+            "app.kubernetes.io/version": "undefined",
+          },
+        },
+        "spec": {
+          "containers": [
+            {
+              "env": [
+                {
+                  "name": "RAZZLE_INTERNAL_API_PATH",
+                  "value": "http://plone-backend-service-c87548c4:8080/Plone",
+                },
+              ],
+              "envFrom": [],
+              "image": "plone/plone-frontend:latest",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "frontend-container",
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/",
+                  "port": 3000,
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 15,
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "500m",
+                  "memory": "1Gi",
+                },
+                "requests": {
+                  "cpu": "200m",
+                  "memory": "256Mi",
+                },
+              },
+            },
+          ],
+          "imagePullSecrets": [],
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "policy/v1",
+    "kind": "PodDisruptionBudget",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-pdb-c8e94afa",
+    },
+    "spec": {
+      "minAvailable": 1,
+      "selector": {
+        "matchLabels": {
+          "app": "plone-frontend-c88fef5c",
+        },
+      },
+    },
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "labels": {
+        "app.kubernetes.io/component": "service",
+        "app.kubernetes.io/managed-by": "cdk8s-plone",
+        "app.kubernetes.io/name": "plone-frontend-service",
+        "app.kubernetes.io/part-of": "plone",
+      },
+      "name": "plone-frontend-service-c87c3840",
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "frontend-http",
+          "port": 3000,
+          "targetPort": 3000,
+        },
+      ],
+      "selector": {
+        "app": "plone-frontend-c88fef5c",
+      },
+    },
+  },
+  {
+    "apiVersion": "vinyl.bluedynamics.eu/v1alpha1",
+    "kind": "VinylCache",
+    "metadata": {
+      "name": "plone-test-vinylcache-c80a8790",
+    },
+    "spec": {
+      "backends": [
+        {
+          "name": "plone_backend",
+          "port": 8080,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/ok",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-backend-service-c87548c4",
+          },
+        },
+        {
+          "name": "plone_frontend",
+          "port": 3000,
+          "probe": {
+            "interval": "5s",
+            "threshold": 8,
+            "timeout": "2s",
+            "url": "/",
+            "window": 10,
+          },
+          "serviceRef": {
+            "name": "plone-frontend-service-c87c3840",
+          },
+        },
+      ],
+      "director": {
+        "type": "shard",
+      },
+      "image": "varnish:7.6",
+      "invalidation": {
+        "ban": {
+          "enabled": true,
+        },
+        "purge": {
+          "enabled": true,
+        },
+        "xkey": {
+          "enabled": true,
+        },
+      },
+      "replicas": 2,
+      "resources": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "512Mi",
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi",
+        },
+      },
+      "storage": [
+        {
+          "name": "s0",
+          "size": "1Gi",
+          "type": "malloc",
+        },
+      ],
+      "vcl": {
+        "snippets": {
+          "vclBackendResponse": "# Plone vcl_backend_response snippet for cloud-vinyl
+# Injected into vcl_backend_response
+
+# Remove Set-Cookie from static resources
+if (bereq.url ~ "\\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js|svg|woff|woff2|ttf|eot)(\\?.*)?$") {
+  unset beresp.http.Set-Cookie;
+}
+
+# Don't cache responses with Set-Cookie
+if (beresp.http.Set-Cookie) {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Don't cache private responses
+if (beresp.http.Cache-Control ~ "private") {
+  set beresp.uncacheable = true;
+  return (deliver);
+}
+
+# Default TTL for responses without Cache-Control
+if (!beresp.http.Cache-Control) {
+  set beresp.ttl = 30s;
+  set beresp.grace = 60s;
+}
+",
+          "vclRecv": "# Plone vcl_recv snippet for cloud-vinyl
+# Injected into vcl_recv after routing, before return()
+
+# Handle PURGE requests from Kubernetes network
+if (req.method == "PURGE") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  return (purge);
+}
+
+# Handle BAN requests
+if (req.method == "BAN") {
+  if (!client.ip ~ purge) {
+    return (synth(405, "Not allowed"));
+  }
+  ban("obj.http.x-url ~ " + req.http.x-ban-url +
+      " && obj.http.x-host ~ " + req.http.x-ban-host);
+  return (synth(200, "Ban added"));
+}
+
+# Detect authenticated requests
+if (req.http.Cookie ~ "__ac" || req.http.Authorization) {
+  set req.http.X-Plone-Auth = "true";
+  return (pass);
+}
+
+# Remove tracking cookies to improve cache hit rate
+if (req.http.Cookie) {
+  set req.http.Cookie = regsuball(req.http.Cookie, "(^|;\\s*)(_ga[^=]*|_gid|_gat|__utm[a-z]+|_hj[a-z]+|_fbp|_fbc)=[^;]*", "");
+  set req.http.Cookie = regsuball(req.http.Cookie, "^;\\s*", "");
+  if (req.http.Cookie ~ "^\\s*$") {
+    unset req.http.Cookie;
+  }
+}
+",
+        },
+      },
+    },
+  },
+]
+`;
+
 exports[`with tolerations 1`] = `
 [
   {

--- a/test/vinylcache.test.ts
+++ b/test/vinylcache.test.ts
@@ -271,6 +271,70 @@ test('shard options ignored when director is non-shard', () => {
   expect(vc.spec.director.shard).toBeUndefined();
 });
 
+test('with storage malloc', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'plone');
+  const plone = new Plone(chart, 'plone');
+
+  // WHEN
+  new PloneVinylCache(chart, 'test', {
+    plone,
+    storage: [
+      { name: 's0', type: 'malloc', size: '1Gi' },
+    ],
+  });
+
+  // THEN
+  const manifest = Testing.synth(chart);
+  const vc = manifest.find((m: any) => m.kind === 'VinylCache');
+  expect(vc).toBeDefined();
+  expect(vc.spec.storage).toEqual([
+    { name: 's0', type: 'malloc', size: '1Gi' },
+  ]);
+  expect(manifest).toMatchSnapshot();
+});
+
+test('with storage file + malloc', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'plone');
+  const plone = new Plone(chart, 'plone');
+
+  // WHEN
+  new PloneVinylCache(chart, 'test', {
+    plone,
+    storage: [
+      { name: 'mem', type: 'malloc', size: '500M' },
+      { name: 'disk', type: 'file', path: '/var/lib/varnish/disk.bin', size: '5Gi' },
+    ],
+  });
+
+  // THEN
+  const manifest = Testing.synth(chart);
+  const vc = manifest.find((m: any) => m.kind === 'VinylCache');
+  expect(vc.spec.storage).toEqual([
+    { name: 'mem', type: 'malloc', size: '500M' },
+    { name: 'disk', type: 'file', path: '/var/lib/varnish/disk.bin', size: '5Gi' },
+  ]);
+  expect(manifest).toMatchSnapshot();
+});
+
+test('without storage omits spec.storage', () => {
+  // GIVEN
+  const app = Testing.app();
+  const chart = new Chart(app, 'plone');
+  const plone = new Plone(chart, 'plone');
+
+  // WHEN
+  new PloneVinylCache(chart, 'test', { plone });
+
+  // THEN
+  const manifest = Testing.synth(chart);
+  const vc = manifest.find((m: any) => m.kind === 'VinylCache');
+  expect(vc.spec.storage).toBeUndefined();
+});
+
 test('exposes vinylCacheServiceName', () => {
   // GIVEN
   const app = Testing.app();


### PR DESCRIPTION
## Summary

- Adds a typed `storage` option on `PloneVinylCacheOptions` that maps to the VinylCache CRD's `spec.storage[]` (malloc + file).
- Without an explicit entry, the cloud-vinyl operator ships varnishd with its stock default (~100 MB malloc), regardless of the pod's memory limit — so users have been monkey-patching `spec.storage` into the generated CR. This removes the need for the workaround.
- Docs: reference table + sizing example in the how-to.

## Requires

cloud-vinyl **v0.4.1+** on the cluster side — earlier versions accepted `spec.storage` on the CR but never forwarded the entries to varnishd as `-s` args (fixed in https://github.com/bluedynamics/cloud-vinyl/pull/38).

## Test plan

- [x] `npx projen test` — new tests for malloc, malloc+file, and the default-omitted case; snapshots updated
- [x] `npx projen eslint` — no errors
- [x] `make -C documentation docs` — builds clean
- [ ] Consumer-side verification in `aaf-6` stage once released: replace the existing `/spec/storage` `JsonPatch` with the construct option and confirm the synthesized manifest is byte-identical for the malloc case

🤖 Generated with [Claude Code](https://claude.com/claude-code)