### PR TITLE
chore(docs): sync reference with current code and add three how-to guides

### DIFF
--- a/documentation/sources/how-to/configure-security-context.md
+++ b/documentation/sources/how-to/configure-security-context.md
@@ -1,0 +1,139 @@
+```{image} ../_static/kup6s-icon-howto.svg
+:align: center
+:class: section-icon-large
+```
+
+# Configure security context
+
+<div class="page-metadata">
+  <div class="metadata-content">
+    <p><strong>Type</strong>: How-To (Task-oriented)</p>
+    <p><strong>Difficulty</strong>: Intermediate</p>
+    <p><strong>Time</strong>: 10 minutes</p>
+  </div>
+</div>
+
+This guide shows you how to harden backend and frontend pods by setting a Kubernetes container security context through `cdk8s-plone`.
+Use it when your cluster enforces Pod Security Standards, when an admission webhook rejects permissive pods, or when you want to apply least-privilege defaults.
+
+## Prerequisites
+
+- A working Plone deployment using `cdk8s-plone`.
+- A Plone image that runs as a non-root user (the official `plone/plone-backend` and `plone/plone-frontend` images do).
+- Cluster knowledge of any namespace-level Pod Security Standards in effect.
+
+## Apply a baseline hardened context
+
+Set `securityContext` on `backend` or `frontend` (or both).
+
+```typescript
+import { Plone, PloneVariant } from '@bluedynamics/cdk8s-plone';
+
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  backend: {
+    image: 'plone/plone-backend:6.1.3',
+    securityContext: {
+      runAsNonRoot: true,
+      allowPrivilegeEscalation: false,
+      capabilities: {
+        drop: ['ALL'],
+      },
+    },
+  },
+  frontend: {
+    image: 'plone/plone-frontend:16.0.0',
+    securityContext: {
+      runAsNonRoot: true,
+      allowPrivilegeEscalation: false,
+      capabilities: {
+        drop: ['ALL'],
+      },
+    },
+  },
+});
+```
+
+These four settings satisfy the Kubernetes **restricted** Pod Security Standard for containers that do not need extra capabilities.
+
+## Pin the UID and GID
+
+If your cluster requires explicit user and group IDs (for example, when you mount shared volumes), set them:
+
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  securityContext: {
+    runAsUser: 500,
+    runAsGroup: 500,
+    runAsNonRoot: true,
+  },
+}
+```
+
+The official Plone backend image already uses UID `500`.
+Match that UID to keep file permissions consistent with the image.
+
+## Mount the root filesystem read-only
+
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  securityContext: {
+    runAsNonRoot: true,
+    readOnlyRootFilesystem: true,
+    allowPrivilegeEscalation: false,
+    capabilities: {
+      drop: ['ALL'],
+    },
+  },
+}
+```
+
+```{warning}
+A read-only root filesystem breaks any container that writes outside mounted volumes.
+Plone's Zope writes temporary files; verify the pod stays `Ready` after rollout.
+Mount writable `emptyDir` volumes for `/tmp` and the Zope `var/` directory through `podAnnotations` or the underlying `Deployment` patches if you hit `EROFS` errors.
+```
+
+## Add a specific capability
+
+When you must add a Linux capability, drop everything else first.
+
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  securityContext: {
+    runAsNonRoot: true,
+    allowPrivilegeEscalation: false,
+    capabilities: {
+      add: ['SYS_PTRACE'],
+      drop: ['ALL'],
+    },
+  },
+}
+```
+
+## Verify the rollout
+
+```bash
+# Generate manifests
+cdk8s synth
+
+# Confirm the securityContext appears on the pod template
+grep -A 10 securityContext dist/*.yaml
+
+# Apply and check pod status
+kubectl apply -f dist/
+kubectl rollout status deployment/<plone-backend-deployment> -n <namespace>
+
+# Inspect the running container
+kubectl exec -n <namespace> deployment/<plone-backend-deployment> -- id
+```
+
+A pod that fails to start with `CreateContainerConfigError` or `permission denied` usually points to a UID, capability, or read-only conflict.
+
+## See also
+
+- {doc}`/reference/configuration-options` — Full `PloneSecurityContext` reference.
+- [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) — Cluster-level policy reference.

--- a/documentation/sources/how-to/enable-prometheus-monitoring.md
+++ b/documentation/sources/how-to/enable-prometheus-monitoring.md
@@ -1,0 +1,114 @@
+```{image} ../_static/kup6s-icon-howto.svg
+:align: center
+:class: section-icon-large
+```
+
+# Enable Prometheus monitoring
+
+<div class="page-metadata">
+  <div class="metadata-content">
+    <p><strong>Type</strong>: How-To (Task-oriented)</p>
+    <p><strong>Difficulty</strong>: Intermediate</p>
+    <p><strong>Time</strong>: 15 minutes</p>
+  </div>
+</div>
+
+This guide shows you how to expose Plone metrics to Prometheus by creating a `ServiceMonitor` for the backend, the frontend, or the Varnish cache.
+
+## Prerequisites
+
+- The [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) installed in the cluster (it provides the `ServiceMonitor` CRD).
+- A `Prometheus` resource that selects the `ServiceMonitor` resources you create (check `serviceMonitorSelector` and `serviceMonitorNamespaceSelector`).
+- A Plone container instrumented to expose metrics over HTTP. Plone itself does not ship a Prometheus endpoint; you need an add-on (such as a WSGI middleware) or a sidecar exporter.
+
+## Enable the ServiceMonitor on the backend
+
+```typescript
+import { Plone, PloneVariant } from '@bluedynamics/cdk8s-plone';
+
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  backend: {
+    image: 'plone/plone-backend:6.1.3',
+    servicemonitor: true,
+    metricsPath: '/metrics',
+  },
+  frontend: {
+    image: 'plone/plone-frontend:16.0.0',
+  },
+});
+```
+
+`servicemonitor: true` instructs `cdk8s-plone` to emit a `ServiceMonitor` that scrapes the backend Service on its main port at `/metrics`.
+
+## Scrape the frontend on a dedicated port
+
+Volto can expose metrics on a separate port through middleware such as [`express-prometheus-middleware`](https://www.npmjs.com/package/express-prometheus-middleware).
+Point `cdk8s-plone` at that port:
+
+```typescript
+frontend: {
+  image: 'plone/plone-frontend:16.0.0',
+  servicemonitor: true,
+  metricsPort: 9090,
+  metricsPath: '/metrics',
+}
+```
+
+`metricsPort` accepts a port number or a Service port name.
+
+## Scrape the Varnish cache
+
+`PloneHttpcache` and `PloneVinylCache` each accept their own monitoring switch.
+
+```typescript
+import { PloneHttpcache } from '@bluedynamics/cdk8s-plone';
+
+new PloneHttpcache(chart, 'cache', {
+  plone: ploneInstance,
+  servicemonitor: true,
+  exporterEnabled: true,
+});
+```
+
+`exporterEnabled` (default `true`) deploys the Varnish exporter sidecar that the `ServiceMonitor` scrapes.
+
+For the cloud-vinyl operator:
+
+```typescript
+import { PloneVinylCache } from '@bluedynamics/cdk8s-plone';
+
+new PloneVinylCache(chart, 'cache', {
+  plone: ploneInstance,
+  monitoring: true,
+});
+```
+
+## Verify the rollout
+
+```bash
+# Generate manifests and confirm the ServiceMonitor exists
+cdk8s synth
+grep -l 'kind: ServiceMonitor' dist/*.yaml
+
+# Apply and inspect on the cluster
+kubectl apply -f dist/
+kubectl get servicemonitor -n <namespace>
+kubectl describe servicemonitor <name> -n <namespace>
+```
+
+If Prometheus is not picking up the new target, confirm:
+
+- The `ServiceMonitor` namespace matches the `Prometheus` resource's `serviceMonitorNamespaceSelector`.
+- The `ServiceMonitor` labels match the `Prometheus` resource's `serviceMonitorSelector`.
+- The metrics endpoint returns HTTP 200 from a pod in the cluster:
+
+  ```bash
+  kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+    curl -sf http://<service>.<namespace>:<port>/metrics | head
+  ```
+
+## See also
+
+- {doc}`/reference/configuration-options` — Reference for `servicemonitor`, `metricsPort`, `metricsPath`.
+- [Prometheus Operator documentation](https://prometheus-operator.dev/) — `ServiceMonitor` selectors and lifecycle.

--- a/documentation/sources/how-to/index.md
+++ b/documentation/sources/how-to/index.md
@@ -42,20 +42,19 @@ deploy-with-vinyl-cache
 maxdepth: 1
 titlesonly: true
 ---
+configure-security-context
+schedule-pods
 ```
 
-*Configuration guides will be added in future releases.*
-
-## Operations & Maintenance
+## Operations & maintenance
 
 ```{toctree}
 ---
 maxdepth: 1
 titlesonly: true
 ---
+enable-prometheus-monitoring
 ```
-
-*Operations guides will be added in future releases.*
 
 ## Troubleshooting
 

--- a/documentation/sources/how-to/schedule-pods.md
+++ b/documentation/sources/how-to/schedule-pods.md
@@ -1,0 +1,141 @@
+```{image} ../_static/kup6s-icon-howto.svg
+:align: center
+:class: section-icon-large
+```
+
+# Schedule pods to specific nodes
+
+<div class="page-metadata">
+  <div class="metadata-content">
+    <p><strong>Type</strong>: How-To (Task-oriented)</p>
+    <p><strong>Difficulty</strong>: Intermediate</p>
+    <p><strong>Time</strong>: 10 minutes</p>
+  </div>
+</div>
+
+This guide shows you how to control where Plone backend, frontend, and Varnish pods run.
+Use `nodeSelector` to require specific node labels and tolerations to schedule onto tainted nodes.
+
+## Prerequisites
+
+- A working Plone deployment using `cdk8s-plone`.
+- Cluster labels and taints already configured on the target nodes.
+
+  ```bash
+  kubectl get nodes --show-labels
+  kubectl describe node <node> | grep Taints
+  ```
+
+## Constrain pods to labeled nodes
+
+Add `nodeSelector` to `backend`, `frontend`, or both.
+Every label in the selector must match for a node to be considered.
+
+```typescript
+import { Plone, PloneVariant } from '@bluedynamics/cdk8s-plone';
+
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  backend: {
+    image: 'plone/plone-backend:6.1.3',
+    nodeSelector: {
+      'topology.kubernetes.io/region': 'fsn1',
+      'workload': 'plone',
+    },
+  },
+  frontend: {
+    image: 'plone/plone-frontend:16.0.0',
+    nodeSelector: {
+      'workload': 'plone',
+    },
+  },
+});
+```
+
+## Schedule the cache onto the same nodes
+
+`PloneVinylCache` exposes the same `nodeSelector` option.
+
+```typescript
+import { PloneVinylCache } from '@bluedynamics/cdk8s-plone';
+
+new PloneVinylCache(chart, 'cache', {
+  plone: ploneInstance,
+  nodeSelector: {
+    'workload': 'plone',
+  },
+});
+```
+
+`PloneHttpcache` schedules through the underlying mittwald Helm chart and does not expose a `nodeSelector` option directly.
+Use cluster-level affinity rules or taints when you need to constrain those pods.
+
+## Tolerate tainted nodes
+
+When nodes carry a taint, pods must declare a matching toleration before the scheduler places them there.
+Both cache constructs accept a `tolerations` list.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: ploneInstance,
+  tolerations: [
+    {
+      key: 'workload',
+      operator: 'Equal',
+      value: 'plone',
+      effect: 'NoSchedule',
+    },
+  ],
+});
+```
+
+```typescript
+new PloneVinylCache(chart, 'cache', {
+  plone: ploneInstance,
+  tolerations: [
+    {
+      key: 'workload',
+      operator: 'Equal',
+      value: 'plone',
+      effect: 'NoSchedule',
+    },
+  ],
+});
+```
+
+`operator: 'Exists'` matches any value for that key.
+Omit `effect` to tolerate every effect for the matching taint.
+
+## Combine selector and toleration
+
+Selectors and tolerations work together: the selector narrows the candidate nodes, and the toleration unblocks the scheduler when those nodes are tainted.
+
+```typescript
+new PloneVinylCache(chart, 'cache', {
+  plone: ploneInstance,
+  nodeSelector: {
+    'workload': 'plone',
+  },
+  tolerations: [
+    { key: 'workload', operator: 'Equal', value: 'plone', effect: 'NoSchedule' },
+  ],
+});
+```
+
+## Verify the rollout
+
+```bash
+cdk8s synth
+kubectl apply -f dist/
+
+# Confirm pods landed on the expected nodes
+kubectl get pods -n <namespace> -o wide
+```
+
+A pod stuck in `Pending` with `0/N nodes are available: ... node(s) had untolerated taint` means a taint is not tolerated.
+`0/N nodes are available: ... node(s) didn't match Pod's node affinity/selector` means the `nodeSelector` does not match any node.
+
+## See also
+
+- {doc}`/reference/configuration-options` — `nodeSelector`, `HttpcacheToleration`, `VinylCacheToleration` reference.
+- [Kubernetes: Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) — Selectors, affinity, and taints.

--- a/documentation/sources/reference/configuration-options.md
+++ b/documentation/sources/reference/configuration-options.md
@@ -89,14 +89,14 @@ const options: PloneOptions = {
 
 Configuration for backend or frontend components.
 
-#### Container Configuration
+#### Container configuration
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
-| `image` | `string` | Yes | - | Container image (e.g., 'plone/plone-backend:6.1.3') |
-| `imagePullPolicy` | `string` | No | `'IfNotPresent'` | Image pull policy |
+| `image` | `string` | No | `plone/plone-backend:latest` (backend) / `plone/plone-frontend:latest` (frontend) | Container image |
+| `imagePullPolicy` | `string` | No | `IfNotPresent` | Image pull policy |
 | `replicas` | `number` | No | `2` | Number of pod replicas |
-| `environment` | `Env` | No | - | Environment variables (cdk8s-plus-30.Env) |
+| `environment` | `Env` | No | - | Environment variables (cdk8s-plus-30 `Env`) |
 
 **Example:**
 ```typescript
@@ -115,14 +115,14 @@ backend: {
 }
 ```
 
-#### Resource Configuration
+#### Resource configuration
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `requestCpu` | `string` | CPU request (e.g., '500m', '1') |
-| `limitCpu` | `string` | CPU limit |
-| `requestMemory` | `string` | Memory request (e.g., '512Mi', '1Gi') |
-| `limitMemory` | `string` | Memory limit |
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `requestCpu` | `string` | `200m` | CPU request |
+| `limitCpu` | `string` | `500m` | CPU limit |
+| `requestMemory` | `string` | `256Mi` | Memory request |
+| `limitMemory` | `string` | `512Mi` (backend) / `1Gi` (frontend) | Memory limit |
 
 **Example:**
 ```typescript
@@ -135,12 +135,12 @@ backend: {
 }
 ```
 
-#### High Availability
+#### High availability
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `minAvailable` | `number` | Minimum pods available during updates (for PodDisruptionBudget) |
-| `maxUnavailable` | `number` | Maximum unavailable pods during updates |
+| `minAvailable` | `number \| string` | Minimum pods available during updates (for PodDisruptionBudget). Accepts an absolute number or a percentage string such as `"50%"`. |
+| `maxUnavailable` | `number \| string` | Maximum unavailable pods during updates. Accepts an absolute number or a percentage string such as `"50%"`. |
 
 **Example:**
 ```typescript
@@ -151,16 +151,16 @@ backend: {
 }
 ```
 
-#### Readiness Probe
+#### Readiness probe
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `readinessEnabled` | `boolean` | `true` | Enable readiness probe |
-| `readinessInitialDelaySeconds` | `number` | - | Seconds before first probe |
-| `readinessTimeoutSeconds` | `number` | - | Probe timeout |
-| `readinessPeriodSeconds` | `number` | - | Probe frequency |
-| `readinessSuccessThreshold` | `number` | - | Consecutive successes required |
-| `readinessFailureThreshold` | `number` | - | Consecutive failures before marking unready |
+| `readinessInitialDelaySeconds` | `number` | `10` | Seconds before first probe |
+| `readinessTimeoutSeconds` | `number` | `15` | Probe timeout |
+| `readinessPeriodSeconds` | `number` | `10` | Probe frequency |
+| `readinessSuccessThreshold` | `number` | `1` | Consecutive successes required |
+| `readinessFailureThreshold` | `number` | `3` | Consecutive failures before marking unready |
 
 **Example:**
 ```typescript
@@ -174,16 +174,16 @@ backend: {
 }
 ```
 
-#### Liveness Probe
+#### Liveness probe
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `livenessEnabled` | `boolean` | `false` | Enable liveness probe (recommended `true` for frontend) |
-| `livenessInitialDelaySeconds` | `number` | - | Seconds before first probe |
-| `livenessTimeoutSeconds` | `number` | - | Probe timeout |
-| `livenessPeriodSeconds` | `number` | - | Probe frequency |
-| `livenessSuccessThreshold` | `number` | - | Consecutive successes required |
-| `livenessFailureThreshold` | `number` | - | Consecutive failures before restart |
+| `livenessInitialDelaySeconds` | `number` | `30` | Seconds before first probe |
+| `livenessTimeoutSeconds` | `number` | `5` | Probe timeout |
+| `livenessPeriodSeconds` | `number` | `10` | Probe frequency |
+| `livenessSuccessThreshold` | `number` | `1` | Consecutive successes required |
+| `livenessFailureThreshold` | `number` | `3` | Consecutive failures before restart |
 
 **Example:**
 ```typescript
@@ -219,6 +219,92 @@ backend: {
 }
 ```
 
+#### Prometheus monitoring
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `servicemonitor` | `boolean` | `false` | Create a Prometheus `ServiceMonitor` for this component. Requires the Prometheus Operator. |
+| `metricsPort` | `string \| number` | main service port | Service port name or number that exposes metrics. |
+| `metricsPath` | `string` | `/metrics` | HTTP path the Prometheus scraper requests. |
+
+You must instrument the backend or frontend container to expose metrics at the configured endpoint.
+For step-by-step setup, see {doc}`/how-to/enable-prometheus-monitoring`.
+
+**Example:**
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  servicemonitor: true,
+  metricsPath: '/metrics',
+},
+frontend: {
+  image: 'plone/plone-frontend:16.0.0',
+  servicemonitor: true,
+  metricsPort: 9090,
+}
+```
+
+#### Scheduling
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `nodeSelector` | `Record<string, string>` | - | Constrain pods to nodes whose labels match all entries. |
+
+For tainted nodes and taint-based scheduling, see {doc}`/how-to/schedule-pods`.
+
+**Example:**
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  nodeSelector: {
+    'topology.kubernetes.io/region': 'fsn1',
+  },
+}
+```
+
+#### Security context
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `securityContext` | `PloneSecurityContext` | - | Container security settings (capabilities, UID/GID, read-only root, privilege escalation). |
+
+**`PloneSecurityContext` fields:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `capabilities` | `PloneCapabilities` | Linux capabilities to add or drop. |
+| `runAsUser` | `number` | Run the container as this UID. |
+| `runAsGroup` | `number` | Run the container as this GID. |
+| `runAsNonRoot` | `boolean` | Require the container to run as non-root. |
+| `readOnlyRootFilesystem` | `boolean` | Mount the root filesystem read-only. |
+| `allowPrivilegeEscalation` | `boolean` | Allow the process to gain more privileges than its parent. |
+| `privileged` | `boolean` | Run the container in privileged mode. |
+
+**`PloneCapabilities` fields:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `add` | `string[]` | Capabilities to add (e.g., `'SYS_PTRACE'`). |
+| `drop` | `string[]` | Capabilities to drop (e.g., `'ALL'`). |
+
+For a hardening walk-through, see {doc}`/how-to/configure-security-context`.
+
+**Example:**
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  securityContext: {
+    runAsNonRoot: true,
+    runAsUser: 500,
+    readOnlyRootFilesystem: true,
+    allowPrivilegeEscalation: false,
+    capabilities: {
+      drop: ['ALL'],
+    },
+  },
+}
+```
+
 ---
 
 ### `PloneHttpcacheOptions`
@@ -228,18 +314,36 @@ Configuration for the Varnish HTTP cache layer.
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `plone` | `Plone` | Yes | - | Plone construct to attach cache to |
-| `varnishVcl` | `string` | No | - | VCL configuration as string |
-| `varnishVclFile` | `string` | No | - | Path to VCL configuration file |
+| `varnishVcl` | `string` | No | - | VCL configuration as string. Takes precedence over `varnishVclFile`. |
+| `varnishVclFile` | `string` | No | built-in `config/varnish.tpl.vcl` | Path to a VCL template file |
 | `existingSecret` | `string` | No | - | Kubernetes secret for Varnish admin credentials |
 | `replicas` | `number` | No | `2` | Number of Varnish replicas |
-| `requestCpu` | `string` | No | - | CPU request |
-| `limitCpu` | `string` | No | - | CPU limit |
-| `requestMemory` | `string` | No | - | Memory request |
-| `limitMemory` | `string` | No | - | Memory limit |
-| `servicemonitor` | `boolean` | No | `false` | Enable Prometheus ServiceMonitor |
+| `requestCpu` | `string` | No | `100m` | CPU request |
+| `limitCpu` | `string` | No | `500m` | CPU limit |
+| `requestMemory` | `string` | No | `100Mi` | Memory request |
+| `limitMemory` | `string` | No | `500Mi` | Memory limit |
+| `servicemonitor` | `boolean` | No | `false` | Enable Prometheus `ServiceMonitor` |
 | `exporterEnabled` | `boolean` | No | `true` | Enable Prometheus exporter sidecar |
-| `chartVersion` | `string` | No | latest | kube-httpcache Helm chart version |
-| `extraEnvVars` | `HttpcacheEnvVar[]` | No | - | Additional env vars for kube-httpcache container |
+| `chartVersion` | `string` | No | chart latest | kube-httpcache Helm chart version |
+| `appVersion` | `string` | No | matches `chartVersion` | kube-httpcache container image tag |
+| `extraEnvVars` | `HttpcacheEnvVar[]` | No | - | Additional env vars for the kube-httpcache container |
+| `tolerations` | `HttpcacheToleration[]` | No | - | Pod tolerations for tainted nodes |
+
+**`HttpcacheEnvVar` fields:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | `string` | Environment variable name |
+| `value` | `string` | Environment variable value |
+
+**`HttpcacheToleration` fields:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `key` | `string` | - | Taint key to tolerate |
+| `operator` | `string` | `Equal` | `Equal` or `Exists` |
+| `value` | `string` | - | Taint value (required for `Equal`) |
+| `effect` | `string` | - | `NoSchedule`, `PreferNoSchedule`, or `NoExecute`. Omit to tolerate all effects. |
 
 **Example:**
 ```typescript
@@ -302,18 +406,37 @@ Requires the [cloud-vinyl operator](https://github.com/bluedynamics/cloud-vinyl)
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
 | `plone` | `Plone` | Yes | - | Plone construct to attach cache to |
+| `image` | `string` | No | `varnish:7.6` | Container image for the Varnish pods |
 | `replicas` | `number` | No | `2` | Number of Varnish replicas |
 | `requestCpu` | `string` | No | `100m` | CPU request |
 | `limitCpu` | `string` | No | `500m` | CPU limit |
 | `requestMemory` | `string` | No | `256Mi` | Memory request |
 | `limitMemory` | `string` | No | `512Mi` | Memory limit |
 | `storage` | `VinylCacheStorage[]` | No | - | Varnish storage backends. If omitted, the operator falls back to the varnishd default (~100 MB malloc), which is almost always too small. |
-| `director` | `string` | No | `shard` | Director type: shard, round_robin, random, hash |
-| `vclRecvSnippet` | `string` | No | built-in | Custom VCL snippet for vcl_recv |
-| `vclBackendResponseSnippet` | `string` | No | built-in | Custom VCL snippet for vcl_backend_response |
+| `extraBackends` | `VinylCacheBackend[]` | No | - | Additional backends appended after the auto-generated Plone backends. |
+| `director` | `string` | No | `shard` | Director type: `shard`, `round_robin`, `random`, `hash` |
+| `shardBy` | `string` | No | operator default (`HASH`) | Shard director: value to hash (`HASH` or `URL`). Requires cloud-vinyl ≥ 0.4.2. |
+| `shardHealthy` | `string` | No | operator default (`CHOSEN`) | Shard director: backend health requirement (`CHOSEN` or `ALL`). Requires cloud-vinyl ≥ 0.4.2. |
+| `shardRampup` | `string` | No | operator default (`30s`) | Shard director: ramp-up window for newly added backends. |
+| `shardReplicas` | `number` | No | operator default (`67`) | Shard director: Ketama replicas per backend. |
+| `vclRecvSnippet` | `string` | No | built-in `plone-vinyl-recv.vcl` | Custom VCL snippet for `vcl_recv` |
+| `vclBackendResponseSnippet` | `string` | No | built-in `plone-vinyl-backend-response.vcl` | Custom VCL snippet for `vcl_backend_response` |
+| `vclDeliverSnippet` | `string` | No | - | Custom VCL snippet for `vcl_deliver` |
+| `vclHitSnippet` | `string` | No | - | Custom VCL snippet for `vcl_hit` |
+| `vclMissSnippet` | `string` | No | - | Custom VCL snippet for `vcl_miss` |
+| `vclPassSnippet` | `string` | No | - | Custom VCL snippet for `vcl_pass` |
+| `vclPipeSnippet` | `string` | No | - | Custom VCL snippet for `vcl_pipe` |
+| `vclSynthSnippet` | `string` | No | - | Custom VCL snippet for `vcl_synth` |
+| `vclPurgeSnippet` | `string` | No | - | Custom VCL snippet for `vcl_purge` |
+| `vclHashSnippet` | `string` | No | - | Custom VCL snippet for `vcl_hash` |
+| `vclInitSnippet` | `string` | No | - | Custom VCL snippet for `vcl_init` |
+| `vclFiniSnippet` | `string` | No | - | Custom VCL snippet for `vcl_fini` |
+| `vclBackendFetchSnippet` | `string` | No | - | Custom VCL snippet for `vcl_backend_fetch` |
+| `vclBackendErrorSnippet` | `string` | No | - | Custom VCL snippet for `vcl_backend_error` |
 | `invalidation` | `boolean` | No | `true` | Enable PURGE/BAN/xkey cache invalidation |
-| `monitoring` | `boolean` | No | `false` | Enable Prometheus metrics and ServiceMonitor |
-| `tolerations` | `VinylCacheToleration[]` | No | - | Node tolerations for Varnish pods |
+| `monitoring` | `boolean` | No | `false` | Enable Prometheus metrics and `ServiceMonitor` |
+| `tolerations` | `VinylCacheToleration[]` | No | - | Pod tolerations for tainted nodes |
+| `nodeSelector` | `Record<string, string>` | No | - | Constrain Varnish pods to nodes matching all labels. |
 
 **`VinylCacheStorage` fields:**
 
@@ -323,6 +446,36 @@ Requires the [cloud-vinyl operator](https://github.com/bluedynamics/cloud-vinyl)
 | `type` | `'malloc' \| 'file'` | Yes | Storage backend type |
 | `size` | `string` | Yes | Kubernetes resource quantity (e.g. `"1Gi"`, `"500M"`) |
 | `path` | `string` | for `file` | Filesystem path for file-type storage |
+
+**`VinylCacheBackend` fields:**
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `name` | `string` | Yes | - | VCL identifier (must match `^[a-zA-Z][a-zA-Z0-9_]*$`) |
+| `serviceName` | `string` | Yes | - | Kubernetes Service name to use as backend |
+| `port` | `number` | Yes | - | Service port |
+| `probe` | `VinylCacheBackendProbe` | No | - | Health probe configuration |
+| `weight` | `number` | No | operator default | Relative weight in the director. `0` marks the backend as standby. |
+
+**`VinylCacheBackendProbe` fields:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `url` | `string` | `/` | URL to probe |
+| `interval` | `string` | `5s` | Probe interval |
+| `timeout` | `string` | `2s` | Probe timeout |
+| `window` | `number` | `10` | Number of recent probes evaluated |
+| `threshold` | `number` | `8` | Healthy threshold within the window |
+| `expectedResponse` | `number` | `200` | Expected HTTP status code |
+
+**`VinylCacheToleration` fields:**
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `key` | `string` | - | Taint key to tolerate |
+| `operator` | `string` | `Equal` | `Equal` or `Exists` |
+| `value` | `string` | - | Taint value (required for `Equal`) |
+| `effect` | `string` | - | `NoSchedule`, `PreferNoSchedule`, or `NoExecute`. Omit to tolerate all effects. |
 
 **Example:**
 ```typescript
@@ -457,9 +610,12 @@ app.synth();
 
 ---
 
-## See Also
+## See also
 
-- [API Documentation](api/) - Complete API reference
-- [Quick Start Tutorial](../tutorials/01-quick-start.md) - Get started guide
-- [Scale Resources](../how-to/scale-resources.md) - How to adjust resources
-- [Configure Monitoring](../how-to/configure-monitoring.md) - Prometheus setup
+- {doc}`/tutorials/01-quick-start` — Get started guide
+- {doc}`/how-to/deploy-production-volto` — Production-ready Volto deployment
+- {doc}`/how-to/deploy-classic-ui` — Classic UI deployment
+- {doc}`/how-to/deploy-with-vinyl-cache` — `PloneVinylCache` walk-through
+- {doc}`/how-to/enable-prometheus-monitoring` — Wire up `ServiceMonitor`
+- {doc}`/how-to/configure-security-context` — Harden backend and frontend pods
+- {doc}`/how-to/schedule-pods` — `nodeSelector` and `tolerations`


### PR DESCRIPTION
## Summary

- Bring `reference/configuration-options.md` back in line with the current `src/` after several features shipped without doc updates.
- Replace the broken **See Also** links (`scale-resources.md`, `configure-monitoring.md`, `api/`) with working `{doc}` refs.
- Add the three how-to guides the reference now points at.

## What's documented for the first time

**`PloneBaseOptions`** — `securityContext` (+ `PloneSecurityContext` / `PloneCapabilities`), `nodeSelector`, `servicemonitor`, `metricsPort`, `metricsPath`.

**`PloneHttpcacheOptions`** — `appVersion`, `tolerations` (+ `HttpcacheToleration` / `HttpcacheEnvVar` field tables).

**`PloneVinylCacheOptions`** — `image`, `extraBackends` (+ `VinylCacheBackend` / `VinylCacheBackendProbe`), `nodeSelector`, `shardBy` / `shardHealthy` / `shardRampup` / `shardReplicas`, and all twelve additional `vcl*Snippet` hooks (deliver, hit, miss, pass, pipe, synth, purge, hash, init, fini, backend_fetch, backend_error).

## Inaccurate defaults corrected

- `image` is optional (defaults to `:latest`), not required.
- Resource and probe rows now show the actual defaults (`200m`/`500m`, `256Mi`/`512Mi`/`1Gi`, `10`/`15`/`10`/`30`/`5`, threshold `1`/`3`).
- `minAvailable` / `maxUnavailable` accept `number | string`.

## New how-to guides

- `how-to/configure-security-context.md` — baseline hardening, UID/GID pinning, read-only root filesystem, adding capabilities, verification.
- `how-to/enable-prometheus-monitoring.md` — `ServiceMonitor` on backend, frontend, `PloneHttpcache`, `PloneVinylCache`; selector troubleshooting.
- `how-to/schedule-pods.md` — `nodeSelector` + tolerations across Plone and the cache constructs; combined examples; diagnosing `Pending` pods.

`how-to/index.md`: registered under **Configuration** and **Operations & maintenance**, replacing the "coming in future releases" placeholders.

## Out of scope (follow-up work)

- A few pre-existing `myst.xref_missing` warnings in `tutorials/01-quick-start.md`, `explanation/*.md`, `how-to/deploy-*.md`, `how-to/setup-prerequisites.md` reference pages that still don't exist.
- A full plone-docs style sweep (missing YAML `myst.html_meta` frontmatter project-wide; `bash` vs `shell` code fences) — call out only, no changes here.

## Test plan

- [x] `make docs` succeeds, zero new warnings introduced by this branch.
- [x] `make docs-linkcheck` — only pre-existing broken links remain (`6.docs.plone.org` 404s, `ahmetb/kubectx` anchor, npmjs.com 403s).
- [ ] Visual review of the rendered HTML on the GitHub Pages preview after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)