### PR TITLE
chore(docs): fix factual errors and remove placeholder sections

### DIFF
--- a/documentation/sources/explanation/index.md
+++ b/documentation/sources/explanation/index.md
@@ -24,28 +24,6 @@ features
 architecture
 ```
 
-## Key topics
-
-*This section will explain:*
-- Plone architecture and component relationships
-- Backend and Frontend integration
-- Storage architecture for Plone data
-- CDK8S construct patterns and best practices
-- Configuration management strategies
-
-*Future topics:*
-- Security considerations
-- Scaling and high availability considerations
-- Performance optimization
-
-## Design decisions
-
-*This section will document:*
-- Why certain defaults were chosen
-- Trade-offs in configuration approaches
-- Integration strategies with external services
-- Testing philosophy
-
 ---
 
 **Ready to get started?** Jump into the [Tutorials](../tutorials/index.md) for hands-on lessons.

--- a/documentation/sources/how-to/deploy-production-volto.md
+++ b/documentation/sources/how-to/deploy-production-volto.md
@@ -43,14 +43,14 @@ Ensure you have these installed on your cluster:
    kubectl apply -f https://github.com/mittwald/kube-httpcache/releases/latest/download/kube-httpcache.yaml
    ```
 
-4. **PostgreSQL Operator** - Choose one:
+4. **PostgreSQL** - The example provisions the database itself; choose the backend with the `DATABASE` variable in Step 4. Prepare the cluster for your choice:
 
-   **Option A: CloudNativePG** (recommended for production):
+   **Option A: CloudNativePG** (recommended for production) - install the operator:
    ```shell
    kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.24/releases/cnpg-1.24.0.yaml
    ```
 
-   **Option B: Bitnami** (simpler for testing):
+   **Option B: Bitnami** (default; no operator needed) - the example deploys the Bitnami PostgreSQL Helm chart for you, so only the target namespace must exist:
    ```shell
    kubectl create namespace plone
    ```
@@ -110,7 +110,7 @@ CLUSTER_ISSUER=letsencrypt-prod
 
 # Optional: Custom images
 #PLONE_BACKEND_IMAGE=plone/plone-backend:6.1.3
-#PLONE_FRONTEND_IMAGE=plone/plone-frontend:latest
+#PLONE_FRONTEND_IMAGE=plone/plone-frontend:16.0.0
 
 # Database: 'bitnami' or 'cloudnativepg'
 DATABASE=cloudnativepg

--- a/documentation/sources/how-to/enable-prometheus-monitoring.md
+++ b/documentation/sources/how-to/enable-prometheus-monitoring.md
@@ -88,6 +88,10 @@ new PloneVinylCache(chart, 'cache', {
 });
 ```
 
+```{note}
+The option name differs by construct: backend, frontend, and `PloneHttpcache` use `servicemonitor`, while `PloneVinylCache` uses `monitoring`. Both create a Prometheus `ServiceMonitor`.
+```
+
 ## Verify the rollout
 
 ```shell

--- a/documentation/sources/how-to/index.md
+++ b/documentation/sources/how-to/index.md
@@ -60,10 +60,6 @@ titlesonly: true
 enable-prometheus-monitoring
 ```
 
-## Troubleshooting
-
-*This section will be populated with troubleshooting guides in future releases.*
-
 ---
 
 **New to cdk8s-plone?** Start with the [Tutorials](../tutorials/index.md) for step-by-step lessons.

--- a/documentation/sources/tutorials/01-quick-start.md
+++ b/documentation/sources/tutorials/01-quick-start.md
@@ -15,7 +15,7 @@ This tutorial will guide you through deploying your first Plone instance using c
 
 Before you start, ensure you have:
 
-- **Node.js 16+** and npm installed
+- **Node.js 18+** and npm installed
 - **kubectl** configured to access your Kubernetes cluster
 - Basic familiarity with Kubernetes and TypeScript
 - A Kubernetes cluster (local or remote)

--- a/documentation/sources/tutorials/index.md
+++ b/documentation/sources/tutorials/index.md
@@ -36,7 +36,7 @@ titlesonly: true
 
 These tutorials assume you have:
 - Basic familiarity with Kubernetes concepts
-- Node.js 16+ and npm installed
+- Node.js 18+ and npm installed
 - A Kubernetes cluster (local or remote)
 - kubectl configured to access your cluster
 - Basic TypeScript knowledge


### PR DESCRIPTION
Second PR from the docs audit — concrete factual fixes (independent of #167).

- **Bitnami prerequisite** in `deploy-production-volto.md`: "Option B: Bitnami" only showed `kubectl create namespace` with no explanation. The example actually supports **both** backends via the `DATABASE` variable (default `bitnami`), and Bitnami needs no operator because the cdk8s app deploys the Bitnami Helm chart itself. Both options are now explained clearly.
- **Image-tag consistency**: the commented `PLONE_FRONTEND_IMAGE` example used `:latest` while the rest of the docs pin `16.0.0`; made it consistent.
- **Node.js version**: tutorials said 16+, the production guide says 18+; cdk8s requires 18+. Aligned tutorials to 18+.
- **Placeholder sections removed**: empty "Troubleshooting" (how-to index) and "Key topics / Future topics / Design decisions" stubs (explanation index) — the real content is in `features.md` / `architecture.md`.
- **Monitoring naming**: noted that `servicemonitor` (backend/frontend/httpcache) vs `monitoring` (vinyl) both produce a `ServiceMonitor`.

Builds clean (`make docs`, zero warnings).

Note on version pins: the image tags are already consistent (`6.1.3` / `16.0.0`) and listed in `setup-prerequisites.md`. True single-source centralization via MyST substitutions is **not possible inside fenced code blocks**, so no fragile mechanism was added — see the discussion on the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)