### PR TITLE
chore(docs): fill how-to, explanation, and tutorial gaps from the audit

### DIFF
--- a/documentation/sources/explanation/architecture.md
+++ b/documentation/sources/explanation/architecture.md
@@ -103,35 +103,35 @@ The library is published in multiple languages:
 
 ```mermaid
 graph TB
-    subgraph "External Access"
-        Client[Client/Browser]
+    subgraph "External access"
+        Client[Client / Browser]
         Ingress[Ingress Controller]
     end
 
-    subgraph "HTTP Cache Layer (Optional)"
-        Varnish[Varnish Cache<br/>kube-httpcache]
+    subgraph "Cache layer (optional)"
+        Varnish[Varnish<br/>PloneHttpcache or PloneVinylCache]
     end
 
-    subgraph "Plone Frontend (Volto)"
+    subgraph "Frontend (Volto variant only)"
         FrontendSvc[Frontend Service]
-        Frontend1[Frontend Pod 1]
-        Frontend2[Frontend Pod 2]
+        Frontend1[Frontend Pod]
+        Frontend2[Frontend Pod]
     end
 
-    subgraph "Plone Backend (API)"
+    subgraph "Backend (REST API for Volto, HTML for Blicca)"
         BackendSvc[Backend Service]
-        Backend1[Backend Pod 1]
-        Backend2[Backend Pod 2]
-        Backend3[Backend Pod 3]
+        Backend1[Backend Pod]
+        Backend2[Backend Pod]
     end
 
-    subgraph "Data Layer"
-        DB[(External Database<br/>PostgreSQL/MySQL/Oracle<br/>with RelStorage)]
+    subgraph "Data layer"
+        DB[(PostgreSQL<br/>with RelStorage)]
     end
 
     Client --> Ingress
     Ingress --> Varnish
-    Varnish -.cache miss.-> FrontendSvc
+    Varnish -.Volto: cache miss.-> FrontendSvc
+    Varnish -.Blicca: cache miss.-> BackendSvc
     Varnish -.invalidation.-> BackendSvc
 
     FrontendSvc --> Frontend1
@@ -142,11 +142,9 @@ graph TB
 
     BackendSvc --> Backend1
     BackendSvc --> Backend2
-    BackendSvc --> Backend3
 
     Backend1 --> DB
     Backend2 --> DB
-    Backend3 --> DB
 ```
 
 ## Component responsibilities

--- a/documentation/sources/explanation/cdk8s-workflow.md
+++ b/documentation/sources/explanation/cdk8s-workflow.md
@@ -1,0 +1,66 @@
+---
+myst:
+  html_meta:
+    "description": "How cdk8s-plone fits into the cdk8s workflow: constructs, synthesis to Kubernetes manifests, and applying them by hand or through GitOps."
+    "property=og:description": "How cdk8s-plone fits into the cdk8s workflow: constructs, synthesis to Kubernetes manifests, and applying them by hand or through GitOps."
+    "property=og:title": "About the cdk8s workflow"
+    "keywords": "Plone, cdk8s, Kubernetes, synth, constructs, GitOps, ArgoCD, Helm"
+---
+
+# About the cdk8s workflow
+
+This page explains where `cdk8s-plone` sits in the cdk8s workflow and why that workflow looks the way it does.
+It is background reading, not a set of steps; for the steps, see {doc}`/tutorials/01-quick-start`.
+
+## Code, synth, apply
+
+[cdk8s](https://cdk8s.io/) is a framework for defining Kubernetes resources in a general-purpose programming language.
+You write TypeScript or Python that constructs objects, run a synthesis step, and get plain Kubernetes YAML.
+Nothing about cdk8s talks to a cluster: it is a manifest generator.
+
+The workflow has three distinct phases, and keeping them apart explains most of how cdk8s-plone behaves.
+First you write code that instantiates constructs inside an `App` and one or more `Chart` objects.
+Then you run `cdk8s synth`, which evaluates that code and writes Kubernetes manifests into the `dist/` directory.
+Finally you apply those manifests to a cluster, either with `kubectl apply` or through a GitOps controller.
+
+The separation matters because the manifests are an ordinary, reviewable artifact.
+You can read the YAML, diff it across changes, and run policy checks on it before anything reaches the cluster.
+
+## Where cdk8s-plone fits
+
+`cdk8s-plone` is a construct library, not an application you run.
+You compose its constructs, mainly `Plone` and one of the cache constructs, inside your own cdk8s app.
+A construct is a reusable building block: `Plone` expands into the Deployments, Services, and optional PodDisruptionBudget and ServiceMonitor that a Plone site needs, with production-minded defaults you can override.
+
+This is the same idea as a Helm chart or a Kustomize base, but expressed in code rather than templated YAML.
+Because the inputs are typed options rather than free-form values, your editor and the compiler catch mistakes before synthesis, and the {doc}`API reference </reference/api/index>` is generated from those types.
+
+## Synthesis time versus apply time
+
+The two cache constructs illustrate the phase distinction well, because they resolve at different times.
+
+`PloneHttpcache` renders the mittwald kube-httpcache Helm chart during synthesis.
+It shells out to the `helm` CLI, so `helm` must be present where you run `cdk8s synth`, and the chart's resources land in your `dist/` output as ordinary manifests.
+
+`PloneVinylCache` instead emits a `VinylCache` custom resource.
+That resource does nothing on its own; the cloud-vinyl operator reconciles it at apply time and creates the underlying Varnish deployment in the cluster.
+The work happens later, and in a different place, than the synthesis that produced the manifest.
+
+Neither approach is universally better.
+Rendering at synthesis keeps everything in one reviewable artifact, while delegating to an operator keeps the cluster as the source of truth and lets the operator manage the cache over its lifetime.
+For the practical trade-offs between the two caches, see {doc}`architecture`.
+
+## Applying by hand or through GitOps
+
+Because synthesis produces plain YAML, you can apply it however you already deploy Kubernetes resources.
+A small project applies `dist/` directly with `kubectl`.
+A larger one commits the synthesized manifests to a repository and lets a GitOps controller such as Argo CD or Flux reconcile them, so the cluster always matches what is in version control.
+
+A common middle path runs `cdk8s synth` in continuous integration and publishes the result, so the synthesis is reproducible and the applied manifests are auditable.
+In every case the cdk8s-plone code stays the single definition of the deployment, and the manifests are a derived, inspectable product of it.
+
+## See also
+
+- {doc}`architecture` — the components a `Plone` construct creates and how they relate.
+- {doc}`/tutorials/01-quick-start` — the workflow applied end to end.
+- [cdk8s documentation](https://cdk8s.io/docs/latest/) — the framework this builds on.

--- a/documentation/sources/explanation/index.md
+++ b/documentation/sources/explanation/index.md
@@ -22,6 +22,7 @@ titlesonly: true
 ---
 features
 architecture
+cdk8s-workflow
 ```
 
 ---

--- a/documentation/sources/how-to/backup-and-restore.md
+++ b/documentation/sources/how-to/backup-and-restore.md
@@ -1,0 +1,107 @@
+---
+myst:
+  html_meta:
+    "description": "Back up and restore a cdk8s-plone deployment by protecting the PostgreSQL database that holds the Plone content."
+    "property=og:description": "Back up and restore a cdk8s-plone deployment by protecting the PostgreSQL database that holds the Plone content."
+    "property=og:title": "Back up and restore"
+    "keywords": "Plone, cdk8s, Kubernetes, backup, restore, PostgreSQL, CloudNativePG, pg_dump, RelStorage"
+---
+
+# Back up and restore
+
+This guide shows you how to back up and restore a Plone deployment.
+
+`cdk8s-plone` does not run backups.
+It deploys the application; your data lives in PostgreSQL, so you protect the database.
+
+## What to back up
+
+Plone stores its content in the ZODB, which this stack keeps in PostgreSQL through RelStorage.
+A backup of the PostgreSQL database is a backup of your site content.
+
+If your configuration keeps blobs on a separate volume rather than in the database, back up that volume as well.
+The application images and Kubernetes manifests are reproducible from your `cdk8s-plone` code, so they do not need a backup.
+
+## Back up a CloudNativePG database
+
+CloudNativePG performs scheduled and on-demand backups to object storage through its own resources.
+
+Configure object-store backups on the `Cluster`, then schedule them with a `ScheduledBackup`:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: plone-daily
+spec:
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: <cluster-name>
+```
+
+Take an immediate backup with a `Backup` resource:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: plone-manual
+spec:
+  cluster:
+    name: <cluster-name>
+```
+
+See the [CloudNativePG backup documentation](https://cloudnative-pg.io/documentation/current/backup/) for object-store credentials and retention policies.
+
+## Back up a Bitnami or standalone database
+
+For a database without an operator, take a logical dump with `pg_dump` from a client pod:
+
+```shell
+kubectl exec -n <namespace> <postgres-pod> -- \
+  pg_dump -U <user> -d <database> -Fc -f /tmp/plone.dump
+kubectl cp <namespace>/<postgres-pod>:/tmp/plone.dump ./plone.dump
+```
+
+Run this on a schedule with a `CronJob`, and store the dump off-cluster.
+
+## Restore
+
+For CloudNativePG, create a new `Cluster` with a `bootstrap.recovery` stanza that points at a backup, following the [CloudNativePG recovery guide](https://cloudnative-pg.io/documentation/current/recovery/).
+
+For a logical dump, restore into an empty database with `pg_restore`:
+
+```shell
+kubectl cp ./plone.dump <namespace>/<postgres-pod>:/tmp/plone.dump
+kubectl exec -n <namespace> <postgres-pod> -- \
+  pg_restore -U <user> -d <database> --clean --if-exists /tmp/plone.dump
+```
+
+After the database is restored, restart the backend so it reconnects:
+
+```shell
+kubectl rollout restart deployment/<backend-deployment> -n <namespace>
+```
+
+```{warning}
+Restoring overwrites the current database.
+Take a fresh backup before you restore, so you can return to the current state if the restore goes wrong.
+```
+
+## Verify
+
+Confirm a backup completed and is recent:
+
+```shell
+kubectl get backup -n <namespace>
+kubectl get scheduledbackup -n <namespace>
+```
+
+After a restore, open the site and confirm your content is present.
+
+## See also
+
+- {doc}`/how-to/upgrade-and-rollout` — back up before a risky upgrade.
+- {doc}`/explanation/architecture` — where Plone stores its data.
+- [CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/) — backup, recovery, and retention.

--- a/documentation/sources/how-to/configure-env-and-secrets.md
+++ b/documentation/sources/how-to/configure-env-and-secrets.md
@@ -1,0 +1,184 @@
+---
+myst:
+  html_meta:
+    "description": "Configure environment variables and secrets on Plone backend and frontend pods with cdk8s-plone using the cdk8s-plus Env API."
+    "property=og:description": "Configure environment variables and secrets on Plone backend and frontend pods with cdk8s-plone using the cdk8s-plus Env API."
+    "property=og:title": "Configure environment variables and secrets"
+    "keywords": "Plone, cdk8s, Kubernetes, environment variables, secrets, ConfigMap, imagePullSecrets, Env"
+---
+
+# Configure environment variables and secrets
+
+This guide shows you how to set environment variables on Plone backend and frontend pods and how to source sensitive values from Kubernetes Secrets and ConfigMaps.
+Use it to inject a RelStorage DSN, an admin password, or any runtime configuration without baking values into the image.
+
+## Prerequisites
+
+- A working Plone deployment using `cdk8s-plone`.
+- Familiarity with the cdk8s-plus `Env` API and the `EnvValue` helpers it provides.
+- `kubectl` access to the target namespace for creating Secrets and ConfigMaps.
+
+## Set a plain environment variable on the backend
+
+Pass an `environment` object to `backend`.
+Build each value with `Env.value` for a literal string.
+
+```typescript
+import { Plone, PloneVariant } from '@bluedynamics/cdk8s-plone';
+import { Env } from 'cdk8s-plus-30';
+
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  backend: {
+    image: 'plone/plone-backend:6.1.3',
+    environment: {
+      variables: {
+        PLONE_TIMEZONE: Env.value('Europe/Vienna'),
+        ZSERVER_THREADS: Env.value('4'),
+      },
+    },
+  },
+});
+```
+
+The `environment` option is typed as the cdk8s-plus `Env` construct.
+Its `variables` map takes an `EnvValue` for every entry, so always wrap raw strings in `Env.value`.
+
+## Reference a value from a Secret
+
+Store sensitive values such as a RelStorage DSN or an admin password in a Kubernetes Secret, then reference them with `Env.fromSecret`.
+
+First create the Secret in the cluster.
+
+```shell
+kubectl create secret generic plone-backend-secrets \
+  --namespace <namespace> \
+  --from-literal=relstorage-dsn='dbname=plone host=db user=plone password=s3cret' \
+  --from-literal=admin-password='change-me'
+```
+
+Reference the existing Secret by name, then read individual keys from it.
+
+```typescript
+import { Plone, PloneVariant } from '@bluedynamics/cdk8s-plone';
+import { Env, Secret } from 'cdk8s-plus-30';
+
+const backendSecret = Secret.fromSecretName(
+  chart,
+  'backend-secret',
+  'plone-backend-secrets',
+);
+
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  backend: {
+    image: 'plone/plone-backend:6.1.3',
+    environment: {
+      variables: {
+        RELSTORAGE_DSN: Env.fromSecret(backendSecret, 'relstorage-dsn'),
+        ADMIN_PASSWORD: Env.fromSecret(backendSecret, 'admin-password'),
+      },
+    },
+  },
+});
+```
+
+`Env.fromSecret` renders a `secretKeyRef` in the pod template, so the value never appears in plain text in the synthesized manifest.
+
+## Reference a value from a ConfigMap
+
+For non-sensitive configuration that you manage separately from the chart, read keys from a ConfigMap with `Env.fromConfigMap`.
+
+```typescript
+import { Env, ConfigMap } from 'cdk8s-plus-30';
+
+const settings = ConfigMap.fromConfigMapName(
+  chart,
+  'settings',
+  'plone-settings',
+);
+
+// inside backend.environment.variables:
+//   LOG_LEVEL: Env.fromConfigMap(settings, 'log-level'),
+```
+
+## Set variables on the frontend
+
+The frontend accepts the same `environment` option as the backend.
+
+```typescript
+import { Plone, PloneVariant } from '@bluedynamics/cdk8s-plone';
+import { Env } from 'cdk8s-plus-30';
+
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  frontend: {
+    image: 'plone/plone-frontend:16.0.0',
+    environment: {
+      variables: {
+        RAZZLE_API_PATH: Env.value('https://plone.example.com/++api++'),
+      },
+    },
+  },
+});
+```
+
+The Volto frontend automatically injects `RAZZLE_INTERNAL_API_PATH` when you do not set it.
+Override it through `environment` only when your service topology requires a non-default internal address.
+
+```typescript
+frontend: {
+  image: 'plone/plone-frontend:16.0.0',
+  environment: {
+    variables: {
+      RAZZLE_INTERNAL_API_PATH: Env.value('http://plone-backend:8080/Plone'),
+    },
+  },
+}
+```
+
+## Pull from a private registry
+
+Image registry credentials are not environment variables.
+List the names of existing pull secrets in the top-level `imagePullSecrets` option.
+
+```typescript
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  imagePullSecrets: ['my-registry-credentials'],
+  backend: {
+    image: 'registry.example.com/plone-backend:6.1.3',
+  },
+  frontend: {
+    image: 'registry.example.com/plone-frontend:16.0.0',
+  },
+});
+```
+
+Create the pull secret beforehand with `kubectl create secret docker-registry <name>`.
+
+## Verify
+
+Synthesize the manifests and inspect the rendered Deployment for the expected entries.
+
+```shell
+cdk8s synth
+
+# Confirm literal values and secret references appear on the backend container
+grep -A 3 'RELSTORAGE_DSN' dist/*.yaml
+grep -B 1 -A 4 'secretKeyRef' dist/*.yaml
+```
+
+A `secretKeyRef` block in the output confirms the value resolves at runtime from the Secret rather than being stored in the manifest.
+After applying, check that the variables reach the container.
+
+```shell
+kubectl apply -f dist/
+kubectl exec -n <namespace> deployment/<plone-backend-deployment> -- env | grep RELSTORAGE_DSN
+```
+
+## See also
+
+- {doc}`/reference/api/index` — full construct and option reference.
+- {doc}`/reference/configuration-options` — guide to `environment` and `imagePullSecrets`.
+- {doc}`/how-to/configure-security-context` — harden the pods that run with these variables.

--- a/documentation/sources/how-to/configure-ingress-tls.md
+++ b/documentation/sources/how-to/configure-ingress-tls.md
@@ -1,0 +1,108 @@
+---
+myst:
+  html_meta:
+    "description": "Expose a cdk8s-plone deployment with a Kubernetes Ingress and TLS certificates from cert-manager."
+    "property=og:description": "Expose a cdk8s-plone deployment with a Kubernetes Ingress and TLS certificates from cert-manager."
+    "property=og:title": "Configure ingress and TLS"
+    "keywords": "Plone, cdk8s, Kubernetes, ingress, TLS, cert-manager, Traefik, Volto"
+---
+
+# Configure ingress and TLS
+
+This guide shows you how to expose a Plone deployment to the internet with a Kubernetes Ingress and TLS certificates from cert-manager.
+
+`cdk8s-plone` does not create ingress resources.
+It creates the Services you route to, and you add the ingress yourself.
+
+## Prerequisites
+
+- A working Plone deployment created with `cdk8s-plone`.
+- An ingress controller in the cluster, such as [Traefik](https://doc.traefik.io/traefik/) or [ingress-nginx](https://kubernetes.github.io/ingress-nginx/).
+- [cert-manager](https://cert-manager.io/) installed, with a `ClusterIssuer` for your certificate authority.
+- DNS records for your domains pointing at the ingress controller.
+
+## Identify the services to route to
+
+The constructs expose the Service names you need as read-only members:
+
+```typescript
+const plone = new Plone(chart, 'plone', {
+  backend: { image: 'plone/plone-backend:6.1.3' },
+  frontend: { image: 'plone/plone-frontend:16.0.0' },
+});
+
+const backendService = plone.backendServiceName;   // backend REST API, port 8080
+const frontendService = plone.frontendServiceName; // Volto frontend, port 3000 (Volto only)
+```
+
+Both Services name their port `http`, so reference them by that name in an Ingress.
+For the Blicca variant there is no frontend Service; route public traffic to the backend instead.
+When you run a cache, route public traffic to the cache Service from {doc}`/how-to/deploy-with-httpcache` or {doc}`/how-to/deploy-with-vinyl-cache`.
+
+## Add an Ingress with TLS
+
+Apply an Ingress that routes your domain to the frontend Service and requests a certificate through cert-manager.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: plone
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  tls:
+    - hosts:
+        - plone.example.com
+      secretName: plone-tls
+  rules:
+    - host: plone.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: <frontendServiceName>
+                port:
+                  name: http
+```
+
+cert-manager watches the `tls` block and the `cluster-issuer` annotation, issues the certificate, and stores it in the `plone-tls` Secret.
+
+## Route a cache, an API, and a maintenance domain
+
+A production setup commonly uses three domains:
+
+- a public domain that points at the Varnish cache Service,
+- an uncached domain that points at the frontend Service for testing,
+- a maintenance domain that points at the backend Service for the Plone control panel.
+
+Add one `host` rule per domain, each with its own `tls` entry, pointing at the matching Service.
+
+```{tip}
+The [production-volto example](https://github.com/bluedynamics/cdk8s-plone/tree/main/examples/production-volto) implements this three-domain pattern with Traefik `IngressRoute` resources in `ingress.ts`.
+Use it as a complete, tested reference, including the Kong and Traefik variants.
+```
+
+## Verify
+
+Confirm the ingress and certificate exist and resolve:
+
+```shell
+kubectl get ingress -n <namespace>
+kubectl get certificate -n <namespace>
+kubectl describe certificate plone-tls -n <namespace>
+```
+
+Once the certificate is `Ready`, request the site over HTTPS:
+
+```shell
+curl -sI https://plone.example.com/
+```
+
+## See also
+
+- {doc}`/how-to/deploy-with-httpcache` — route public traffic through Varnish.
+- {doc}`/how-to/deploy-production-volto` — a full deployment that includes ingress and TLS.
+- {doc}`/reference/api/index` — `backendServiceName` and `frontendServiceName` reference.

--- a/documentation/sources/how-to/deploy-with-httpcache.md
+++ b/documentation/sources/how-to/deploy-with-httpcache.md
@@ -1,0 +1,224 @@
+---
+myst:
+  html_meta:
+    "description": "Deploy the PloneHttpcache Varnish cache via the mittwald kube-httpcache Helm chart and attach it to a Plone deployment."
+    "property=og:description": "Deploy the PloneHttpcache Varnish cache via the mittwald kube-httpcache Helm chart and attach it to a Plone deployment."
+    "property=og:title": "Deploy with PloneHttpcache"
+    "keywords": "Plone, cdk8s, Kubernetes, Varnish, kube-httpcache, mittwald, PloneHttpcache, caching, VCL"
+---
+
+# Deploy with PloneHttpcache
+
+This guide shows you how to deploy the `PloneHttpcache` Varnish cache and attach it to an existing Plone instance.
+
+`PloneHttpcache` deploys Varnish through the [mittwald kube-httpcache](https://github.com/mittwald/kube-httpcache) Helm chart.
+The construct renders that chart at synth time, so the cache is part of your own manifests.
+For an operator-managed alternative, see {doc}`/how-to/deploy-with-vinyl-cache`.
+
+## Prerequisites
+
+- A running Plone deployment created with `cdk8s-plone` (see {doc}`/tutorials/01-quick-start`).
+- The `helm` CLI available wherever you run `cdk8s synth`.
+- A Kubernetes `Secret` holding the Varnish admin credentials, referenced through `existingSecret`.
+- amd64 worker nodes.
+
+The construct renders the kube-httpcache Helm chart locally, so you do not pre-install a controller in the cluster.
+The pod `nodeSelector` is hard-coded to `kubernetes.io/arch=amd64` (a kube-httpcache workaround), so `PloneHttpcache` pods only schedule on amd64 nodes.
+There is no `nodeSelector` option on this construct.
+
+Create the admin credentials Secret before you deploy:
+
+```shell
+kubectl create secret generic varnish-admin \
+  --namespace <namespace> \
+  --from-literal=secret="$(head -c32 /dev/urandom | base64)"
+```
+
+## Attach a basic PloneHttpcache
+
+Construct `PloneHttpcache` with a `plone` reference, the `existingSecret`, and a `replicas` count.
+
+```typescript
+import { Plone, PloneHttpcache } from '@bluedynamics/cdk8s-plone';
+
+const plone = new Plone(chart, 'plone', {
+  backend: { image: 'plone/plone-backend:6.1.3' },
+  frontend: { image: 'plone/plone-frontend:16.0.0' },
+});
+
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  replicas: 2,
+});
+```
+
+RBAC for the rendered controller is always enabled; there is nothing to configure.
+
+## Set resources
+
+Tune the CPU and memory requests and limits to match your workload.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  requestCpu: '200m',
+  limitCpu: '1',
+  requestMemory: '256Mi',
+  limitMemory: '1Gi',
+});
+```
+
+The defaults are `requestCpu: '100m'`, `limitCpu: '500m'`, `requestMemory: '100Mi'`, and `limitMemory: '500Mi'`.
+
+## Customize the VCL
+
+Provide an inline VCL through `varnishVcl`, which takes precedence over `varnishVclFile`.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  varnishVcl: `
+vcl 4.1;
+backend default {
+  .host = "{{ .Env.BACKEND_SERVICE_NAME }}";
+  .port = "{{ .Env.BACKEND_SERVICE_PORT }}";
+}
+`,
+});
+```
+
+Alternatively, point `varnishVclFile` at a VCL template file on disk; the construct reads it at synth time.
+When you set neither option, the construct uses the built-in `config/varnish.tpl.vcl`.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  varnishVclFile: './config/varnish.tpl.vcl',
+});
+```
+
+VCL templates use Go template syntax.
+The construct supplies these environment variables: `BACKEND_SERVICE_NAME`, `BACKEND_SERVICE_PORT`, `BACKEND_SITE_ID`, `FRONTEND_SERVICE_NAME`, and `FRONTEND_SERVICE_PORT`.
+Reference them as `{{ .Env.NAME }}`.
+
+Add your own variables through `extraEnvVars`, which are appended to the built-in set.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  extraEnvVars: [
+    { name: 'THUMBOR_SERVICE_NAME', value: 'my-thumbor' },
+  ],
+});
+```
+
+Reference an extra variable in your VCL template as `{{ .Env.THUMBOR_SERVICE_NAME }}`.
+
+## Schedule the cache pods
+
+Add `tolerations` so the cache pods can run on tainted nodes.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  tolerations: [
+    { key: 'dedicated', operator: 'Equal', value: 'cache', effect: 'NoSchedule' },
+  ],
+});
+```
+
+Omit `effect` to tolerate every taint for the given key.
+`operator` defaults to `'Equal'`.
+
+## Enable monitoring
+
+Set `servicemonitor` to emit a Prometheus `ServiceMonitor`, and keep `exporterEnabled` so the Varnish exporter sidecar is present for it to scrape.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  servicemonitor: true,
+  exporterEnabled: true,
+});
+```
+
+`exporterEnabled` defaults to `true`, and `servicemonitor` defaults to `false`.
+Use `servicemonitor` here; there is no `monitoring` option on this construct.
+For the full monitoring setup, see {doc}`/how-to/enable-prometheus-monitoring`.
+
+## Pin the chart and image versions
+
+Set `chartVersion` to pin the kube-httpcache Helm chart, and `appVersion` to pin the image tag.
+
+```typescript
+new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+  chartVersion: '0.13.1',
+  appVersion: '0.13.1',
+});
+```
+
+`chartVersion` defaults to the latest chart, and `appVersion` defaults to `chartVersion`.
+
+## Point your ingress at the cache
+
+Route external traffic through the cache by using the read-only `httpcacheServiceName` output as your Ingress or IngressRoute upstream instead of the Plone frontend service.
+
+```typescript
+const cache = new PloneHttpcache(chart, 'cache', {
+  plone: plone,
+  existingSecret: 'varnish-admin',
+});
+
+const upstream = cache.httpcacheServiceName;
+```
+
+For the routing and TLS details, see {doc}`/how-to/configure-ingress-tls`.
+
+## Verify the cache
+
+Generate the manifests and confirm the cache resources are present.
+
+```shell
+cdk8s synth
+grep -l 'kube-httpcache' dist/*.yaml
+```
+
+Apply the manifests and inspect the rollout on the cluster.
+
+```shell
+kubectl apply -f dist/
+kubectl get pods -n <namespace>
+kubectl get service -n <namespace>
+```
+
+Send a request through the cache service and check the Varnish response headers.
+
+```shell
+kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+  curl -sI http://<httpcacheServiceName>.<namespace>:80/
+```
+
+A cached response carries an `X-Varnish` header, and an `Age` header greater than zero confirms a cache hit.
+
+## PloneHttpcache compared with PloneVinylCache
+
+`PloneHttpcache` runs Varnish from the mittwald kube-httpcache chart with a Secret and a VCL template that you supply.
+`PloneVinylCache` runs Varnish through the cloud-vinyl operator, which generates VCL from structured configuration and manages credentials for you.
+For the trade-offs between the two, see {doc}`/explanation/architecture` and {doc}`/how-to/deploy-with-vinyl-cache`.
+
+## See also
+
+- {doc}`/reference/api/index` — authoritative `PloneHttpcache` and `PloneHttpcacheOptions` reference.
+- {doc}`/reference/configuration-options` — guide to `varnishVcl`, `existingSecret`, `extraEnvVars`, and `servicemonitor`.
+- {doc}`/how-to/enable-prometheus-monitoring` — scrape the Varnish cache with Prometheus.
+- {doc}`/how-to/deploy-with-vinyl-cache` — operator-managed Varnish caching alternative.
+- [mittwald kube-httpcache](https://github.com/mittwald/kube-httpcache) — upstream controller and Helm chart.

--- a/documentation/sources/how-to/index.md
+++ b/documentation/sources/how-to/index.md
@@ -36,6 +36,7 @@ titlesonly: true
 ---
 deploy-production-volto
 deploy-blicca
+deploy-with-httpcache
 deploy-with-vinyl-cache
 ```
 
@@ -46,11 +47,13 @@ deploy-with-vinyl-cache
 maxdepth: 1
 titlesonly: true
 ---
+configure-env-and-secrets
 configure-security-context
 schedule-pods
+configure-ingress-tls
 ```
 
-## Operations & maintenance
+## Operations and maintenance
 
 ```{toctree}
 ---
@@ -58,6 +61,19 @@ maxdepth: 1
 titlesonly: true
 ---
 enable-prometheus-monitoring
+scale-and-high-availability
+upgrade-and-rollout
+backup-and-restore
+```
+
+## Troubleshooting
+
+```{toctree}
+---
+maxdepth: 1
+titlesonly: true
+---
+troubleshooting
 ```
 
 ---

--- a/documentation/sources/how-to/scale-and-high-availability.md
+++ b/documentation/sources/how-to/scale-and-high-availability.md
@@ -1,0 +1,122 @@
+---
+myst:
+  html_meta:
+    "description": "Scale the Plone backend and frontend with cdk8s-plone, configure a PodDisruptionBudget, and add a HorizontalPodAutoscaler."
+    "property=og:description": "Scale the Plone backend and frontend with cdk8s-plone, configure a PodDisruptionBudget, and add a HorizontalPodAutoscaler."
+    "property=og:title": "Scale and run highly available"
+    "keywords": "Plone, cdk8s, Kubernetes, scaling, replicas, PodDisruptionBudget, HPA, high availability"
+---
+
+# Scale and run highly available
+
+This guide shows you how to run more than one replica of the Plone backend and frontend, protect them with a PodDisruptionBudget, and add a HorizontalPodAutoscaler.
+
+## Prerequisites
+
+- A working Plone deployment created with `cdk8s-plone`.
+- A PostgreSQL backend reachable by every backend replica.
+
+The backend uses RelStorage on PostgreSQL, so several backend replicas share one database and scale horizontally.
+The Volto frontend is stateless and scales horizontally as well.
+
+## Set the replica count
+
+Set `replicas` on `backend` and `frontend` independently.
+
+```typescript
+import { Plone, PloneVariant } from '@bluedynamics/cdk8s-plone';
+
+new Plone(chart, 'plone', {
+  variant: PloneVariant.VOLTO,
+  backend: {
+    image: 'plone/plone-backend:6.1.3',
+    replicas: 3,
+  },
+  frontend: {
+    image: 'plone/plone-frontend:16.0.0',
+    replicas: 2,
+  },
+});
+```
+
+Both default to `2` replicas when you omit the option.
+
+## Protect availability with a PodDisruptionBudget
+
+A PodDisruptionBudget keeps a minimum number of pods running during voluntary disruptions such as node drains.
+
+Set `minAvailable` or `maxUnavailable` on the component.
+Each accepts an absolute number or a percentage string such as `"50%"`.
+
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  replicas: 5,
+  minAvailable: 3,
+}
+```
+
+`cdk8s-plone` creates the PodDisruptionBudget automatically when `replicas` is `2` or more, or when you set `minAvailable` or `maxUnavailable` explicitly.
+A single replica with no explicit setting gets no PodDisruptionBudget.
+The generated PodDisruptionBudget always sets `unhealthyPodEvictionPolicy: AlwaysAllow`, so unhealthy pods never block a node drain.
+
+## Add a HorizontalPodAutoscaler
+
+`cdk8s-plone` emits plain Deployments and does not configure autoscaling.
+To scale on load, add your own HorizontalPodAutoscaler that targets the generated backend Deployment.
+
+Find the Deployment name from the synthesized manifests:
+
+```shell
+cdk8s synth
+grep -A2 'kind: Deployment' dist/*.yaml | grep 'name:'
+```
+
+Add the autoscaler as a Kubernetes manifest and apply it alongside your deployment:
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: plone-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <backend-deployment-name>
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+```
+
+The HorizontalPodAutoscaler needs [metrics-server](https://github.com/kubernetes-sigs/metrics-server) in the cluster.
+Keep `minReplicas` at `2` or more so the PodDisruptionBudget stays effective.
+
+## Verify
+
+Confirm the PodDisruptionBudget is present in the synthesized manifests:
+
+```shell
+cdk8s synth
+grep -l 'kind: PodDisruptionBudget' dist/*.yaml
+```
+
+Inspect the running objects on the cluster:
+
+```shell
+kubectl get deploy -n <namespace>
+kubectl get pdb -n <namespace>
+kubectl get hpa -n <namespace>
+```
+
+## See also
+
+- {doc}`/reference/api/index` — authoritative `replicas`, `minAvailable`, and `maxUnavailable` reference.
+- {doc}`/how-to/schedule-pods` — place the extra replicas on specific nodes.
+- {doc}`/explanation/architecture` — how the backend, frontend, and database fit together.

--- a/documentation/sources/how-to/troubleshooting.md
+++ b/documentation/sources/how-to/troubleshooting.md
@@ -1,0 +1,113 @@
+---
+myst:
+  html_meta:
+    "description": "Diagnose and fix common cdk8s-plone problems: pods not scheduling, crashes, failing probes, database connection errors, and synth failures."
+    "property=og:description": "Diagnose and fix common cdk8s-plone problems: pods not scheduling, crashes, failing probes, database connection errors, and synth failures."
+    "property=og:title": "Troubleshoot a deployment"
+    "keywords": "Plone, cdk8s, Kubernetes, troubleshooting, CrashLoopBackOff, probes, scheduling, synth"
+---
+
+# Troubleshoot a deployment
+
+This guide shows you how to diagnose and fix the problems you are most likely to hit when you deploy Plone with `cdk8s-plone`.
+
+Start by looking at the overall state, then drill into the failing object.
+
+```shell
+kubectl get pods -n <namespace>
+kubectl describe pod <pod> -n <namespace>
+kubectl logs <pod> -n <namespace>
+```
+
+## `cdk8s synth` fails
+
+If `synth` fails while rendering `PloneHttpcache`, confirm the `helm` CLI is installed and on your `PATH`.
+`PloneHttpcache` renders the kube-httpcache Helm chart at synth time and shells out to `helm`.
+
+If `synth` fails on a missing custom resource type, run the example's import step (`npm run import`) to regenerate the CRD bindings.
+
+## Pods stay `Pending`
+
+Describe the pod and read the `Events` section for the scheduler's reason.
+
+```shell
+kubectl describe pod <pod> -n <namespace>
+```
+
+Common causes:
+
+- Insufficient CPU or memory on the nodes. Lower `requestCpu` or `requestMemory`, or add capacity.
+- A `nodeSelector` or `tolerations` setting that no node satisfies. See {doc}`/how-to/schedule-pods`.
+- `PloneHttpcache` pods only schedule on amd64 nodes, because the construct hard-codes `kubernetes.io/arch=amd64`. Provide an amd64 node or use {doc}`/how-to/deploy-with-vinyl-cache` instead.
+
+## A pod is in `CrashLoopBackOff`
+
+Read the logs of the current and previous container starts.
+
+```shell
+kubectl logs <pod> -n <namespace>
+kubectl logs <pod> -n <namespace> --previous
+```
+
+A backend that exits immediately almost always cannot reach its database.
+See {ref}`backend-db-connection`.
+
+(backend-db-connection)=
+
+## The backend cannot reach the database
+
+The backend uses RelStorage on PostgreSQL, so it needs a correct connection string and credentials.
+
+- Confirm the database is running and reachable from the backend namespace.
+- Confirm the environment variable that carries the DSN resolves from its Secret. See {doc}`/how-to/configure-env-and-secrets`.
+
+```shell
+kubectl get secret -n <namespace>
+kubectl exec -n <namespace> deployment/<backend-deployment> -- env | grep -i storage
+```
+
+## Pods never become ready
+
+A pod that stays `Running` but never `Ready` is failing its readiness probe.
+
+- Increase `readinessInitialDelaySeconds` if the backend needs longer to start.
+- Increase `readinessTimeoutSeconds` or `readinessFailureThreshold` for a slow first request.
+
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.3',
+  readinessInitialDelaySeconds: 30,
+  readinessTimeoutSeconds: 15,
+}
+```
+
+Liveness probes are disabled by default (`livenessEnabled` defaults to `false`).
+If pods restart in a loop after you enable liveness, raise `livenessInitialDelaySeconds` so the probe does not fire during startup.
+
+## The cache does not cache
+
+Check the cache pod logs, then confirm requests reach the cache service rather than the backend or frontend directly.
+
+```shell
+kubectl logs -n <namespace> -l app.kubernetes.io/part-of=plone
+kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+  curl -sI http://<cache-service>.<namespace>:80/
+```
+
+A missing `X-Varnish` header means traffic bypasses the cache; point your ingress at the cache service. See {doc}`/how-to/configure-ingress-tls`.
+For VCL behavior, see {doc}`/how-to/deploy-with-httpcache` and {doc}`/how-to/deploy-with-vinyl-cache`.
+
+## Prometheus does not scrape the metrics
+
+If a `ServiceMonitor` exists but no target appears in Prometheus, the selectors do not match.
+
+- Confirm the `ServiceMonitor` namespace matches the `Prometheus` resource's `serviceMonitorNamespaceSelector`.
+- Confirm its labels match the `Prometheus` resource's `serviceMonitorSelector`.
+
+See {doc}`/how-to/enable-prometheus-monitoring` for the full setup.
+
+## See also
+
+- {doc}`/how-to/deploy-production-volto` — a complete deployment to compare against.
+- {doc}`/reference/api/index` — authoritative option and default reference.
+- {doc}`/explanation/architecture` — how the components depend on each other.

--- a/documentation/sources/how-to/upgrade-and-rollout.md
+++ b/documentation/sources/how-to/upgrade-and-rollout.md
@@ -1,0 +1,89 @@
+---
+myst:
+  html_meta:
+    "description": "Upgrade the Plone image and the cdk8s-plone library, roll out changes safely, and roll back a failed update."
+    "property=og:description": "Upgrade the Plone image and the cdk8s-plone library, roll out changes safely, and roll back a failed update."
+    "property=og:title": "Upgrade and roll out"
+    "keywords": "Plone, cdk8s, Kubernetes, upgrade, rollout, rolling update, rollback, migration"
+---
+
+# Upgrade and roll out
+
+This guide shows you how to upgrade the Plone images and the `cdk8s-plone` library, roll the change out safely, and roll it back if it fails.
+
+## Prerequisites
+
+- A working Plone deployment created with `cdk8s-plone`.
+- Two or more replicas if you need a zero-downtime rollout. See {doc}`/how-to/scale-and-high-availability`.
+
+## Upgrade the Plone image
+
+Change the `image` tag on `backend` and `frontend` to the new version.
+
+```typescript
+backend: {
+  image: 'plone/plone-backend:6.1.4',
+},
+frontend: {
+  image: 'plone/plone-frontend:16.1.0',
+}
+```
+
+Pin a specific tag rather than `latest`, so the rollout is reproducible and you can roll back to a known version.
+
+Regenerate the manifests and apply them:
+
+```shell
+cdk8s synth
+kubectl apply -f dist/
+```
+
+Kubernetes replaces the pods with the default RollingUpdate strategy.
+With two or more replicas and a PodDisruptionBudget, the old pods drain only as new pods become ready.
+
+```{important}
+Upgrading to a new Plone major or minor version may require a Plone site upgrade step that `cdk8s-plone` does not perform.
+After the new backend pods are ready, run the upgrade from the Plone control panel (`@@plone-upgrade`) on the maintenance or uncached route.
+```
+
+## Watch the rollout
+
+Follow the rollout and confirm it completes.
+
+```shell
+kubectl rollout status deployment/<backend-deployment> -n <namespace>
+kubectl get pods -n <namespace> -w
+```
+
+## Roll back a failed upgrade
+
+If the new version misbehaves, undo the rollout to the previous ReplicaSet:
+
+```shell
+kubectl rollout undo deployment/<backend-deployment> -n <namespace>
+```
+
+To return to a known-good definition instead, restore the previous image tag in your code, then `cdk8s synth` and `kubectl apply -f dist/` again.
+
+```{warning}
+A rollback reverts the container image, not your data.
+If the upgrade ran an irreversible Plone site migration, restore the database from a backup. See {doc}`/how-to/backup-and-restore`.
+```
+
+## Upgrade the cdk8s-plone library
+
+Bump the dependency, regenerate, and review the manifest diff before applying.
+
+```shell
+npm install @bluedynamics/cdk8s-plone@latest
+cdk8s synth
+git diff dist/
+```
+
+Read the [changelog](https://github.com/bluedynamics/cdk8s-plone/releases) for renamed or deprecated options, then apply the reviewed manifests.
+
+## See also
+
+- {doc}`/how-to/scale-and-high-availability` — replicas and PodDisruptionBudget for zero-downtime rollouts.
+- {doc}`/how-to/backup-and-restore` — back up before a risky upgrade.
+- {doc}`/reference/api/index` — authoritative option reference for each release.

--- a/documentation/sources/tutorials/index.md
+++ b/documentation/sources/tutorials/index.md
@@ -15,12 +15,13 @@ Tutorials are lessons that help you gain practical skills and familiarity with c
 
 ## What you'll learn
 
-These tutorials will teach you how to:
+The quick start teaches you how to:
 
-- Deploy a basic Plone instance using cdk8s-plone
-- Configure PostgreSQL backend
-- Customize component resources and settings
-- Test your deployment
+- Define a Plone deployment with the `Plone` construct
+- Synthesize Kubernetes manifests with `cdk8s synth`
+- Apply the manifests and reach the running site
+
+For tasks beyond the first deployment, such as configuring a database, caching, or scaling, see the {doc}`/how-to/index`.
 
 ## Available tutorials
 


### PR DESCRIPTION
Final PR from the docs audit — fills the coverage gaps. **Stacked on #168** (base is `docs/factual-fixes` for a clean diff); retarget to `main` after #168 merges.

## New how-to guides
- `deploy-with-httpcache` — dedicated PloneHttpcache guide (previously only the vinyl variant had one)
- `configure-env-and-secrets` — env vars, Secrets/ConfigMaps, `imagePullSecrets`
- `scale-and-high-availability` — replicas, PodDisruptionBudget rules, bring-your-own HPA
- `upgrade-and-rollout` — image/library upgrades, rolling update, rollback, Plone site-upgrade step
- `configure-ingress-tls` — Ingress + cert-manager (constructs don't manage ingress)
- `backup-and-restore` — protect the PostgreSQL database (CloudNativePG + pg_dump)
- `troubleshooting` — real cross-cutting guide replacing the placeholder

## New explanation
- `cdk8s-workflow` — code → synth → apply, synth-time vs apply-time, GitOps

## Fixes
- `tutorials/index` "What you'll learn" no longer promises non-existent tutorials
- architecture diagram now shows both caches and both frontend variants (Volto + Blicca)
- all new pages wired into the section toctrees

Every page is grounded in the actual API (verified against `src/`), Diataxis how-to/explanation style, one sentence per line. Builds clean (`make docs`, zero warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)