### PR TITLE
chore(examples): track tsconfig and make example snapshots deterministic

### DIFF
--- a/examples/blicca/__snapshots__/main.test.ts.snap
+++ b/examples/blicca/__snapshots__/main.test.ts.snap
@@ -396,7 +396,7 @@ exports[`Blicca Example Synthesizes correctly 1`] = `
   {
     "apiVersion": "v1",
     "data": {
-      "secret": "Q0luOEI0VURISk4zbkNGZTY4bFZYQ0FrczZFNGNMR00=",
+      "secret": "<redacted-for-snapshot>",
     },
     "kind": "Secret",
     "metadata": {

--- a/examples/blicca/main.test.ts
+++ b/examples/blicca/main.test.ts
@@ -6,6 +6,13 @@ describe('Blicca Example', () => {
     const app = Testing.app();
     const chart = new BliccaChart(app, 'test-chart');
     const results = Testing.synth(chart);
+    // kube-httpcache generates a random Varnish admin secret on each synth.
+    // Redact it so the snapshot stays deterministic.
+    for (const obj of results) {
+      if (obj.kind === 'Secret' && obj.data && typeof obj.data.secret === 'string') {
+        obj.data.secret = '<redacted-for-snapshot>';
+      }
+    }
     expect(results).toMatchSnapshot();
   });
 });

--- a/examples/blicca/tsconfig.json
+++ b/examples/blicca/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "lib": [
+      "ES2020"
+    ],
+    "module": "CommonJS",
+    "noEmit": false,
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "stripInternal": true,
+    "target": "ES2020"
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/examples/volto/__snapshots__/main.test.ts.snap
+++ b/examples/volto/__snapshots__/main.test.ts.snap
@@ -499,7 +499,7 @@ exports[`Production Volto Example Synthesizes correctly 1`] = `
   {
     "apiVersion": "v1",
     "data": {
-      "secret": "ZEhRU2lMbmlBazl4U01FY3dhM2Y5S3FXUE1rWjJweUQ=",
+      "secret": "<redacted-for-snapshot>",
     },
     "kind": "Secret",
     "metadata": {

--- a/examples/volto/main.test.ts
+++ b/examples/volto/main.test.ts
@@ -6,6 +6,13 @@ describe('Production Volto Example', () => {
     const app = Testing.app();
     const chart = new ExampleChart(app, 'test-chart');
     const results = Testing.synth(chart);
+    // kube-httpcache generates a random Varnish admin secret on each synth.
+    // Redact it so the snapshot stays deterministic.
+    for (const obj of results) {
+      if (obj.kind === 'Secret' && obj.data && typeof obj.data.secret === 'string') {
+        obj.data.secret = '<redacted-for-snapshot>';
+      }
+    }
     expect(results).toMatchSnapshot();
   });
 });

--- a/examples/volto/tsconfig.json
+++ b/examples/volto/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "lib": [
+      "ES2020"
+    ],
+    "module": "CommonJS",
+    "noEmit": false,
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "stripInternal": true,
+    "target": "ES2020"
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Fixes two pre-existing tooling issues in the `volto` and `blicca` examples (surfaced while working on #170).

## 1. Track `tsconfig.json`
The examples' `tsconfig.json` was never committed (not gitignored — just missing). Without it, `npm test` / `npm run compile` fail on a fresh clone because ts-jest falls back to broken defaults (`outDir` error, hybrid module kind). Commit the standard example `tsconfig.json` for both examples.

## 2. Deterministic snapshots
The kube-httpcache Helm chart generates a **random Varnish admin secret on every synth**, so the snapshot tests failed on any second run (one `data.secret` line differed every time). The tests now redact that secret before `toMatchSnapshot()`, and both snapshots are regenerated.

Verified: `npx jest` passes on **two consecutive clean runs** in both examples (previously the second run failed).

This is a pure test/tooling change — it does not alter the synthesized deployment.